### PR TITLE
Add inlinestrings function

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,12 @@ inline strings from 1 byte up to 255 bytes.
 
 The following types are supported: `String1`, `String3`, `String7`, `String15`,
 `String31`, `String63`, `String127`, `String255`.
+
+InlineStrings can be constructed by passing an `AbstractString`, byte vector
+(`AbstractVector{UInt8}`) and position and length, or a pointer (`Ptr{UInt8}`)
+and length. See the docstring for any individual InlineString type for more details
+(like `?String3`).
+
+To generically turn any string into the smallest possible InlineString type,
+call `InlineString(x)`. To convert any iterator/array of strings to a single,
+promoted `InlineString` type, the `inlinestrings(A)` utility function is exported.

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -4,7 +4,7 @@ import Base: ==
 
 using Parsers
 
-export InlineString, InlineStringType
+export InlineString, InlineStringType, inlinestrings
 
 """
     InlineString
@@ -761,5 +761,68 @@ function Base.sort!(vs::AbstractVector, lo::Int, hi::Int, ::InlineStringSortAlg,
     end
     return vs
 end
+
+# collections of InlineStrings
+"""
+    inlinestrings(itr) => Vector{<:InlineString}
+
+    Utility function that takes any iterator of `AbstractString` values
+and produces a `Vector` with a single promoted `InlineString` type. That is,
+all iterated elements will be promoted to the smallest `InlineString` subtype
+that can fit all elements. `missing` values are also allowed and will result
+in a result eltype of `Union{Missing, X}` where `X` is an `InlineString` subtype.
+"""
+function inlinestrings(itr::T) where {T}
+    # x must be iterable
+    IS = Base.IteratorSize(T)
+    state = iterate(itr)
+    state === nothing && return Union{}[]
+    y, st = state
+    x = y === missing ? missing : InlineString(y)
+    eT = typeof(x)
+    # allocate res, which will either be same length as `itr` if
+    # IS <: HasLength, or length of 0 if Base.SizeUnknown
+    res = allocate(eT, IS, itr)
+    i = 1
+    # set! push!-es for Base.SizeUnknown, or setindex! for HasLength
+    set!(IS, res, x, i)
+    i += 1
+    # dispatch to separate function for type stability
+    return _inlinestrings(itr, st, eT, IS, res, i)
+end
+
+const HasLength = Union{Base.HasShape, Base.HasLength}
+allocate(::Type{T}, ::HasLength, itr) where {T} = Vector{T}(undef, length(itr))
+allocate(::Type{T}, IS, itr) where {T} = Vector{T}(undef, 0)
+set!(::HasLength, res, x, i) = setindex!(res, x, i)
+set!(IS, res, x, i) = push!(res, x)
+
+function _inlinestrings(itr, st, ::Type{eT}, IS, res, i) where {eT}
+    while true
+        state = iterate(itr, st)
+        state === nothing && break
+        y, st = state
+        if y === missing && eT >: Missing
+            set!(IS, res, missing, i)
+        elseif y !== missing && sizeof(y) < sizeof(eT)
+            set!(IS, res, eT(y), i)
+        else
+            # need to promote and widen res,
+            # then re-dispatch on _inlinestrings for new eltype
+            x = y === missing ? y : InlineString(y)
+            new_eT = promote_type(typeof(x), eT)
+            newres = allocate(new_eT, Base.HasLength(), res)
+            copyto!(newres, 1, res, 1, i - 1)
+            set!(IS, newres, x, i)
+            return _inlinestrings(itr, st, new_eT, IS, newres, i + 1)
+        end
+        i += 1
+    end
+    return res
+end
+
+Base.Broadcast.broadcasted(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
+Base.map(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
+Base.collect(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -216,3 +216,30 @@ end
         end
     end
 end
+
+@testset "inlinestrings" begin
+
+    @test inlinestrings([]) == Union{}[]
+    
+    x = inlinestrings("$i" for i in (1, 10, 100))
+    @test eltype(x) === String3
+    @test x == ["1", "10", "100"]
+    @test eltype(inlinestrings([randstring(i) for i = 1:3])) === String3
+    @test eltype(inlinestrings([randstring(i) for i = 1:4])) === String7
+    @test eltype(inlinestrings(["a", missing, "abcd"])) === Union{String7, Missing}
+    @test eltype(inlinestrings([missing, "abcd"])) === Union{String7, Missing}
+
+    # Base.SizeUnknown() case
+    t() = true
+    x = inlinestrings("$i" for i in (1, 10, 100) if t())
+    @test eltype(x) === String3
+    @test x == ["1", "10", "100"]
+    @test eltype(inlinestrings(randstring(i) for i = 1:3 if t())) === String3
+    @test eltype(inlinestrings(randstring(i) for i = 1:4 if t())) === String7
+    @test eltype(inlinestrings(x for x in ["a", missing, "abcd"] if t())) === Union{String7, Missing}
+    @test eltype(inlinestrings(x for x in [missing, "abcd"] if t())) === Union{String7, Missing}
+
+    x = [randstring(i) for i = 1:31]
+    @test InlineString.(x) == map(InlineString, x) == collect(InlineString, x)
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -219,7 +219,7 @@ end
 
 @testset "inlinestrings" begin
 
-    @test inlinestrings([]) == Union{}[]
+    @test inlinestrings([]) == []
     
     x = inlinestrings("$i" for i in (1, 10, 100))
     @test eltype(x) === String3
@@ -243,4 +243,9 @@ end
     @test InlineString.(x) == map(InlineString, x) == collect(InlineString, x)
     @test eltype(InlineString.(x)) == eltype(map(InlineString, x)) == eltype(collect(InlineString, x)) == InlineString31
 
+    # promote all the way to String
+    x = inlinestrings(randstring(i) for i = 1:256)
+    @test eltype(x) === String
+    x = inlinestrings(i == 1 ? missing : randstring(i) for i = 1:256 if t())
+    @test eltype(x) === Union{Missing, String}
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -241,5 +241,6 @@ end
 
     x = [randstring(i) for i = 1:31]
     @test InlineString.(x) == map(InlineString, x) == collect(InlineString, x)
+    @test eltype(InlineString.(x)) == eltype(map(InlineString, x)) == eltype(collect(InlineString, x)) == InlineString31
 
 end


### PR DESCRIPTION
Fixes #4. We overload `InlinString.(x)`, `map(InlineString, x)`, and
`collect(InlineString, x)` to call down to `inlinestrings(x)` which will
choose the smallest concrete `InlineString` type that can fit all
elements. Can handle any valid iterator as input, even
`Base.SizeUnknown`.