### PR TITLE
Allow missing values when sorting arrays of inline strings

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -681,7 +681,7 @@ function Base.sort!(vs::AbstractVector, lo::Int, hi::Int, ::InlineStringSortAlg,
 
     # Make sure we're sorting a primitive type
     T = Base.Order.ordtype(o, vs)
-    isprimitivetype(T) || requireprimitivetype(T)
+    isprimitivetype(Base.nonmissingtype(T)) || requireprimitivetype(T)
 
     if hi - lo < MergeSortThresholds[sizeof(T)]
         return sort!(vs, lo, hi, MergeSort, o)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -215,6 +215,9 @@ end
             @test sort(x; rev=true) == sort(y; rev=true)
         end
     end
+    x = [missing, String1("b"), String1("a")]
+    sort!(x)
+    @test isequal(x, ["a", "b", missing])
 end
 
 @testset "inlinestrings" begin


### PR DESCRIPTION
Fixes #18. Our validation check wasn't permissive enough to allow
`Union` of `missing` values.