### PR TITLE
Add native versions of chop, chomp, first, and last

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -342,6 +342,7 @@ function Base.chop(s::InlineString; head::Integer = 0, tail::Integer = 1)
     return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), newlen))
 end
 
+Base.chomp(s::InlineString1) = chomp(String3(s))
 function Base.chomp(s::InlineString)
     i = lastindex(s)
     if i < 1 || codeunit(s, i) != 0x0a
@@ -353,6 +354,7 @@ function Base.chomp(s::InlineString)
     end
 end
 
+Base.first(s::InlineString1, n::Integer) = first(String3(s), n)
 function Base.first(s::InlineString, n::Integer)
     i = min(lastindex(s), nextind(s, 0, n))
     newlen = nextind(s, i) - 1
@@ -360,6 +362,7 @@ function Base.first(s::InlineString, n::Integer)
     return Base.or_int(s, _oftype(typeof(s), newlen))
 end
 
+Base.last(s::InlineString1, n::Integer) = last(String3(s), n)
 function Base.last(s::InlineString, n::Integer)
     nc = ncodeunits(s) + 1
     i = max(1, prevind(s, nc, n))

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -329,6 +329,44 @@ function Base.isascii(x::T) where {T <: InlineString}
     return true
 end
 
+Base.chop(s::InlineString1; kw...) = chop(String3(s); kw...)
+function Base.chop(s::InlineString; head::Integer = 0, tail::Integer = 1)
+    if isempty(s)
+        return s
+    end
+    n = ncodeunits(s)
+    i = min(n + 1, max(nextind(s, firstindex(s), head), 1))
+    j = max(0, min(n, prevind(s, lastindex(s), tail)))
+    newlen = max(0, n - ((i - 1) + (n - j)))
+    s = Base.shl_int(Base.lshr_int(s, 8), 8)
+    return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), newlen))
+end
+
+function Base.chomp(s::InlineString)
+    i = lastindex(s)
+    if i < 1 || codeunit(s, i) != 0x0a
+        return s
+    elseif i < 2 || codeunit(s, i - 1) != 0x0d
+        return Base.sub_int(s, 1)
+    else
+        return Base.sub_int(s, 2)
+    end
+end
+
+function Base.first(s::InlineString, n::Integer)
+    i = min(lastindex(s), nextind(s, 0, n))
+    s = Base.shl_int(Base.lshr_int(s, 8), 8)
+    return Base.or_int(s, _oftype(typeof(s), i))
+end
+
+function Base.last(s::InlineString, n::Integer)
+    nc = ncodeunits(s) + 1
+    i = max(1, prevind(s, nc, n))
+    i == 1 && return s
+    newlen = nc - i
+    return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), newlen))
+end
+
 # copy/pasted from substring.jl
 function Base.reverse(s::InlineString)
     # Read characters forwards from `s` and write backwards to `out`

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -347,16 +347,17 @@ function Base.chomp(s::InlineString)
     if i < 1 || codeunit(s, i) != 0x0a
         return s
     elseif i < 2 || codeunit(s, i - 1) != 0x0d
-        return Base.sub_int(s, 1)
+        return Base.sub_int(s, _oftype(typeof(s), 1))
     else
-        return Base.sub_int(s, 2)
+        return Base.sub_int(s, _oftype(typeof(s), 2))
     end
 end
 
 function Base.first(s::InlineString, n::Integer)
     i = min(lastindex(s), nextind(s, 0, n))
+    newlen = nextind(s, i) - 1
     s = Base.shl_int(Base.lshr_int(s, 8), 8)
-    return Base.or_int(s, _oftype(typeof(s), i))
+    return Base.or_int(s, _oftype(typeof(s), newlen))
 end
 
 function Base.last(s::InlineString, n::Integer)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -122,6 +122,24 @@ end # @testset
         write(io, x)
         seekstart(io)
         @test read(io, typeof(x)) === x
+        @test chomp(x) == chomp(y)
+        if typeof(x) != String255
+            @test chomp(InlineString(x * "\n")) == chomp(y * "\n")
+            @test chomp(InlineString(x * "\r\n")) == chomp(y * "\r\n")
+        end
+        @test chop(x) == chop(y)
+        @test chop(x; head=1, tail=0) == chop(y; head=1, tail=0)
+        @test chop(x; head=1) == chop(y; head=1)
+        @test chop(x; head=sizeof(x) + 1) == chop(y; head=sizeof(y) + 1)
+        @test chop(x; head=sizeof(x) + 1, tail=sizeof(x) + 1) == chop(y; head=sizeof(x) + 1, tail=sizeof(y) + 1)
+        @test first(x) == first(y)
+        @test first(x, sizeof(x)) == first(y, sizeof(y))
+        @test first(x, sizeof(x) - 1) == first(y, sizeof(y) - 1)
+        @test first(x, sizeof(x) + 1) == first(y, sizeof(y) + 1)
+        @test last(x) == last(y)
+        @test last(x, sizeof(x)) == last(y, sizeof(y))
+        @test last(x, sizeof(x) - 1) == last(y, sizeof(y) - 1)
+        @test last(x, sizeof(x) + 1) == last(y, sizeof(y) + 1)
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,13 +132,13 @@ end # @testset
         @test chop(x; head=1) == chop(y; head=1)
         @test chop(x; head=sizeof(x) + 1) == chop(y; head=sizeof(y) + 1)
         @test chop(x; head=sizeof(x) + 1, tail=sizeof(x) + 1) == chop(y; head=sizeof(x) + 1, tail=sizeof(y) + 1)
-        @test first(x) == first(y)
+        y != "" && @test first(x) == first(y)
         @test first(x, sizeof(x)) == first(y, sizeof(y))
-        @test first(x, sizeof(x) - 1) == first(y, sizeof(y) - 1)
+        y != "" && @test first(x, sizeof(x) - 1) == first(y, sizeof(y) - 1)
         @test first(x, sizeof(x) + 1) == first(y, sizeof(y) + 1)
-        @test last(x) == last(y)
+        y != "" && @test last(x) == last(y)
         @test last(x, sizeof(x)) == last(y, sizeof(y))
-        @test last(x, sizeof(x) - 1) == last(y, sizeof(y) - 1)
+        y != "" && @test last(x, sizeof(x) - 1) == last(y, sizeof(y) - 1)
         @test last(x, sizeof(x) + 1) == last(y, sizeof(y) + 1)
     end
 end


### PR DESCRIPTION
Fixes #17. Allows returning inline string types from inline string type
inputs.