### PR TITLE
Do not discard parsed values

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -624,7 +624,7 @@ function Parsers.xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos
     code = res.code
     overflowed = false
     poslen = res.val
-    if Parsers.invalid(code) || Parsers.sentinel(code)
+    if !Parsers.valueok(code) || Parsers.sentinel(code)
         x = T()
     else
         poslen = res.val

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -149,7 +149,7 @@ testcases = [
     (" ", InlineString7(" "), NamedTuple(), OK | EOF),
     (" \"", InlineString7(), NamedTuple(), OK | QUOTED | EOF | INVALID_QUOTED_FIELD), # invalid quoted
     (" \"\" ", InlineString7(), NamedTuple(), OK | QUOTED | EOF), # quoted
-    (" \" ", InlineString7(), NamedTuple(), OK | QUOTED | INVALID_QUOTED_FIELD | EOF), # invalid quoted
+    (" \" ", InlineString7(" "), NamedTuple(), OK | QUOTED | INVALID_QUOTED_FIELD | EOF), # invalid quoted
     (" \" \" ", InlineString7(" "), NamedTuple(), OK | QUOTED | EOF), # quoted
     ("NA", InlineString7(), (; sentinel=["NA"]), EOF | SENTINEL), # sentinel
     ("\"\"", InlineString7(), NamedTuple(), OK | QUOTED | EOF), # same e & cq

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, InlineStrings, Parsers, Serialization, Random
-import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED, INVALID_QUOTED_FIELD, ESCAPED_STRING, NEWLINE, SUCCESS, peekbyte, incr!, checksentinel, checkdelim, checkcmtemptylines
+import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED, INVALID_DELIMITER, INVALID_QUOTED_FIELD, ESCAPED_STRING, NEWLINE, SUCCESS, peekbyte, incr!, checksentinel, checkdelim, checkcmtemptylines
 
 @testset "InlineString basics" begin
 
@@ -181,6 +181,7 @@ testcases = [
     ("a\r\n", InlineString7("a"), NamedTuple(), OK | NEWLINE | EOF),
     ("abcdefg", InlineString7("abcdefg"), (; delim=nothing), OK | EOF),
     ("", InlineString7(), (; sentinel=missing), SENTINEL | EOF),
+    ("{abc } xyz", InlineString7("abc "), (; openquotechar='{', closequotechar='}'), OK | QUOTED | EOF | INVALID_DELIMITER),
 ]
 
 for (i, case) in enumerate(testcases)


### PR DESCRIPTION
This makes the `xparse` method for InlineStrings
consistent with how Parsers.jl treats parsed values
(post https://github.com/JuliaData/Parsers.jl/pull/97)

This allows us to continue returning non-empty InlineStrings
when we parse a string but then hit an invalid delimiter,
which occurs in more cases now that Parsers.jl (correctly) marks
quoted strings not followed by a delimiter (or whitespace/newline/EOF)
as encountering an invalid delimiter
(post https://github.com/JuliaData/Parsers.jl/pull/107)