### PR TITLE
Include native version of reverse for InlineStrings

### DIFF
--- a/benchmarks/benchmark.jl
+++ b/benchmarks/benchmark.jl
@@ -1,0 +1,21 @@
+using InlineStrings, BenchmarkTools, Random
+
+const types = [String1, String3, String7, String15, String31, String63, String127, String255]
+
+ascii = [InlineString(randstring(i)) for i in map(x -> sizeof(x) - 1, types)]
+str_ascii = [String(x) for x in ascii]
+utf8 = [InlineString(string("π", x[3:end])) for x in ascii]
+str_utf8 = [String(x) for x in utf8]
+
+function bench(ascii, )
+    for (x, y) in zip(ascii, str_ascii)
+        @show typeof(x), @btime reverse($x)
+        @show typeof(y), @btime reverse($y)
+    end
+
+    for (x, y) in zip(utf8, str_utf8)
+        @show typeof(x), @btime reverse($x)
+        @show typeof(y), @btime reverse($y)
+    end
+end
+bench()

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -323,7 +323,6 @@ function Base.isascii(x::T) where {T <: InlineString}
     len = ncodeunits(x)
     x = Base.lshr_int(x, 8 * (sizeof(T) - len))
     for _ = 1:(len >> 2)
-        # y = Base.trunc_int(UInt32, x) >= 0x80 && return false
         y = Base.trunc_int(UInt32, x)
         (y & 0xff000000) >= 0x80000000 && return false
         (y & 0x00ff0000) >= 0x00800000 && return false

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -65,10 +65,11 @@ ptrstr3 = UInt8['h', 'e', 'y', '1', 0x00]
 
 end # @testset
 
+const STRINGS = ["", "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255]
+const INLINES = map(InlineString, STRINGS)
+
 @testset "InlineString operations" begin
-    for y in ("", "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255)
-        x = InlineString(y)
-        @show typeof(x)
+    for (x, y) in zip(INLINES, STRINGS)
         @test codeunits(x) == codeunits(y)
         @test sizeof(x) == sizeof(y)
         @test ncodeunits(x) == ncodeunits(y)
@@ -273,4 +274,11 @@ end
 
     # https://github.com/JuliaStrings/InlineStrings.jl/issues/25
     @test inlinestrings(fill("a", 100_000)) isa Vector{String1}
+end
+
+@testset "reverse" begin
+    words = split(read(joinpath(dirname(pathof(InlineStrings)), "../test/utf8.txt"), String); keepempty=false)
+    for x in words
+        @test InlineString(x) == String(x)
+    end
 end

--- a/test/utf8.txt
+++ b/test/utf8.txt
@@ -1,0 +1,149 @@
+Sentences that contain all letters commonly used in a language
+--------------------------------------------------------------
+
+Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/> -- 2012-04-11
+
+This is an example of a plain-text file encoded in UTF-8.
+
+
+Danish (da)
+---------
+
+  Quizdeltagerne spiste jordbær med fløde, mens cirkusklovnen
+  Wolther spillede på xylofon.
+  (= Quiz contestants were eating strawbery with cream while Wolther
+  the circus clown played on xylophone.)
+
+German (de)
+-----------
+
+  Falsches Üben von Xylophonmusik quält jeden größeren Zwerg
+  (= Wrongful practicing of xylophone music tortures every larger dwarf)
+
+  Zwölf Boxkämpfer jagten Eva quer über den Sylter Deich
+  (= Twelve boxing fighters hunted Eva across the dike of Sylt)
+
+  Heizölrückstoßabdämpfung
+  (= fuel oil recoil absorber)
+  (jqvwxy missing, but all non-ASCII letters in one word)
+
+Greek (el)
+----------
+
+  Γαζέες καὶ μυρτιὲς δὲν θὰ βρῶ πιὰ στὸ χρυσαφὶ ξέφωτο
+  (= No more shall I see acacias or myrtles in the golden clearing)
+
+  Ξεσκεπάζω τὴν ψυχοφθόρα βδελυγμία
+  (= I uncover the soul-destroying abhorrence)
+
+English (en)
+------------
+
+  The quick brown fox jumps over the lazy dog
+
+Spanish (es)
+------------
+
+  El pingüino Wenceslao hizo kilómetros bajo exhaustiva lluvia y 
+  frío, añoraba a su querido cachorro.
+  (Contains every letter and every accent, but not every combination
+  of vowel + acute.)
+
+French (fr)
+-----------
+
+  Portez ce vieux whisky au juge blond qui fume sur son île intérieure, à
+  côté de l'alcôve ovoïde, où les bûches se consument dans l'âtre, ce
+  qui lui permet de penser à la cænogenèse de l'être dont il est question
+  dans la cause ambiguë entendue à Moÿ, dans un capharnaüm qui,
+  pense-t-il, diminue çà et là la qualité de son œuvre. 
+
+  l'île exiguë
+  Où l'obèse jury mûr
+  Fête l'haï volapük,
+  Âne ex aéquo au whist,
+  Ôtez ce vœu déçu.
+
+  Le cœur déçu mais l'âme plutôt naïve, Louÿs rêva de crapaüter en
+  canoë au delà des îles, près du mälström où brûlent les novæ.
+
+Irish Gaelic (ga)
+-----------------
+
+  D'fhuascail Íosa, Úrmhac na hÓighe Beannaithe, pór Éava agus Ádhaimh
+
+Hungarian (hu)
+--------------
+
+  Árvíztűrő tükörfúrógép
+  (= flood-proof mirror-drilling machine, only all non-ASCII letters)
+
+Icelandic (is)
+--------------
+
+  Kæmi ný öxi hér ykist þjófum nú bæði víl og ádrepa
+
+  Sævör grét áðan því úlpan var ónýt
+  (some ASCII letters missing)
+
+Japanese (jp)
+-------------
+
+  Hiragana: (Iroha)
+
+  いろはにほへとちりぬるを
+  わかよたれそつねならむ
+  うゐのおくやまけふこえて
+  あさきゆめみしゑひもせす
+
+  Katakana:
+
+  イロハニホヘト チリヌルヲ ワカヨタレソ ツネナラム
+  ウヰノオクヤマ ケフコエテ アサキユメミシ ヱヒモセスン
+
+Hebrew (iw)
+-----------
+
+  ? דג סקרן שט בים מאוכזב ולפתע מצא לו חברה איך הקליטה
+
+Polish (pl)
+-----------
+
+  Pchnąć w tę łódź jeża lub ośm skrzyń fig
+  (= To push a hedgehog or eight bins of figs in this boat)
+
+Russian (ru)
+------------
+
+  В чащах юга жил бы цитрус? Да, но фальшивый экземпляр!
+  (= Would a citrus live in the bushes of south? Yes, but only a fake one!)
+
+  Съешь же ещё этих мягких французских булок да выпей чаю
+  (= Eat some more of these fresh French loafs and have some tea) 
+
+Thai (th)
+---------
+
+  [--------------------------|------------------------]
+  ๏ เป็นมนุษย์สุดประเสริฐเลิศคุณค่า  กว่าบรรดาฝูงสัตว์เดรัจฉาน
+  จงฝ่าฟันพัฒนาวิชาการ           อย่าล้างผลาญฤๅเข่นฆ่าบีฑาใคร
+  ไม่ถือโทษโกรธแช่งซัดฮึดฮัดด่า     หัดอภัยเหมือนกีฬาอัชฌาสัย
+  ปฏิบัติประพฤติกฎกำหนดใจ        พูดจาให้จ๊ะๆ จ๋าๆ น่าฟังเอย ฯ
+
+  [The copyright for the Thai example is owned by The Computer
+  Association of Thailand under the Royal Patronage of His Majesty the
+  King.]
+
+Turkish (tr)
+------------
+
+  Pijamalı hasta, yağız şoföre çabucak güvendi.
+  (=Patient with pajamas, trusted swarthy driver quickly)
+
+
+Special thanks to the people from all over the world who contributed
+these sentences since 1999.
+
+A much larger collection of such pangrams is now available at
+
+  http://en.wikipedia.org/wiki/List_of_pangrams


### PR DESCRIPTION
This is the first in a series of PRs where I'm going to attempt to
provide "native" string functions that operate on and return
InlineStrings. The advantage is that when working with InlineStrings,
the normal set of string functions won't "poison" your data by
unnecessarily introducing `String`s, but will operate directly on the
InlineString type and return the same type when possible.

The `reverse` function is a good example of that: it can always return
the same type as the input, and in my benchmarks, it can be 2-4x faster
than the "default" `String` method.