### PR TITLE
Widen `Missing` eltype on first non-`missing`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -882,7 +882,7 @@ function _inlinestrings(itr, st, ::Type{eT}, IS, res, i) where {eT}
         y, st = state
         if y === missing && eT >: Missing
             set!(IS, res, missing, i)
-        elseif y !== missing && sizeof(y) < sizeof(eT) || sizeof(y) == 1
+        elseif y !== missing && eT !== Missing && (sizeof(y) < sizeof(eT) || sizeof(y) == 1)
             set!(IS, res, Base.nonmissingtype(eT)(y), i)
         else
             # need to promote and widen res,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -286,6 +286,8 @@ end
 
     # https://github.com/JuliaStrings/InlineStrings.jl/issues/25
     @test inlinestrings(fill("a", 100_000)) isa Vector{String1}
+    # https://github.com/JuliaStrings/InlineStrings.jl/issues/34
+    @test inlinestrings([missing, "e"]) isa Vector{Union{Missing, String1}}
 end
 
 @testset "reverse" begin


### PR DESCRIPTION
- closes #34 

Before `inlinestrings([missing, "e"])` would fail, even though `inlinestrings(["e", missing])` would succeed as would `inlinestrings([missing, "ee"])`. 
This was because in first case the initial results vector eltype `eT` is set to `Missing` and then when we see a string `y = "e"` we'd have `y !== missing && sizeof(y) == 1` and hit the branch which calls `nonmissingtype(eT)(y)`. 
We only hit this branch when `sizeof(y) == 1` since the otherside of the check, `sizeof(y) < sizeof(eT)`, is always false (since `sizeof(Missing) == 1`). 
(This bug was accidentally introduced by me in !26)
The fix is to never hit this branch if `eT == Missing`.