### PR TITLE
 Fix in promote_type is ambiguous.

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -87,7 +87,7 @@ function Base.promote_rule(::Type{T}, ::Type{S}) where {T <: InlineString, S <: 
     return InlineString255
 end
 
-Base.promote_rule(::Type{T}, ::Type{String}) where {T <: InlineString} = String
+
 
 Base.widen(::Type{InlineString1}) = InlineString3
 Base.widen(::Type{InlineString3}) = InlineString7


### PR DESCRIPTION
Fix on Method Error: promote_type(::Type{Union{}}, ::Type{String}) is ambiguous.

This error occurs when working together with other packages like DataFrames.jl and SQLite.jl when using the command:

DBInterface.execute(db, str) |> DataFrame

The expected return from an SQLite SELECT statement would be a field of the default data type dd/mm/YYYY. However, it ended up generating the following error:
ERROR: promote_type(::Type{Union{}}, ::Type{String}) is ambiguous. T<:WeakRefStrings.InlineString at WeakRefStrings at C:\Users\user\.julia\packages\WeakRefStrings\a3jYm\src\inlinestrings.jl:90

Correction, just remover the ambiguous 90 line:
#Base.promote_type(::Type{T}, ::Type{String}) where {T <: InlineString} = String