### PR TITLE
Fix `chop` on strings with multi-byte graphemes

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -342,11 +342,12 @@ function Base.chop(s::InlineString; head::Integer = 0, tail::Integer = 1)
         return s
     end
     n = ncodeunits(s)
-    i = min(n + 1, max(nextind(s, firstindex(s), head), 1))
-    j = max(0, min(n, prevind(s, lastindex(s), tail)))
-    newlen = max(0, n - ((i - 1) + (n - j)))
-    s = clear_n_bytes(s, sizeof(typeof(s)) - j)
-    return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), newlen))
+    i = min(n + 1, max(nextind(s, firstindex(s), head), 1))  # new firstindex
+    j = max(0, min(n, prevind(s, lastindex(s), tail)))       # new lastindex
+    jx = nextind(s, j) - 1                                   # last codeunit to keep
+    new_n = max(0, nextind(s, j) - i)                        # new ncodeunits
+    s = clear_n_bytes(s, sizeof(typeof(s)) - jx)
+    return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), new_n))
 end
 
 # used to zero out n lower bytes of an inline string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,8 +69,38 @@ abc = InlineString3("abc")
 @test last(abc, 2) == InlineString3("bc")
 @test chop(abc) == InlineString3("ab")
 @test chop(abc; head=1, tail=0) == InlineString3("bc")
+@test chop(abc) isa InlineString3
 @test chomp(InlineString3("ab\n")) == InlineString3("ab")
 @test chomp(InlineString7("ab\r\n")) == InlineString7("ab")
+@test chomp(InlineString7("ab\r\n")) isa InlineString7
+
+# https://github.com/JuliaStrings/InlineStrings.jl/issues/38
+@test chop(InlineString7("Bün")) == InlineString7("Bü")
+
+# chop tests copied from Base
+# https://github.com/JuliaLang/julia/blob/v1.8.2/test/strings/util.jl#L497-L517
+S = InlineString15
+@test chop(S("")) == ""
+@test chop(S("fooε")) == "foo"
+@test chop(S("foεo")) == "foε"
+@test chop(S("∃∃∃∃")) == "∃∃∃"
+@test chop(S("∀ϵ∃Δ"), head=0, tail=0) == "∀ϵ∃Δ"
+@test chop(S("∀ϵ∃Δ"), head=0, tail=1) == "∀ϵ∃"
+@test chop(S("∀ϵ∃Δ"), head=0, tail=2) == "∀ϵ"
+@test chop(S("∀ϵ∃Δ"), head=0, tail=3) == "∀"
+@test chop(S("∀ϵ∃Δ"), head=0, tail=4) == ""
+@test chop(S("∀ϵ∃Δ"), head=0, tail=5) == ""
+@test chop(S("∀ϵ∃Δ"), head=1, tail=0) == "ϵ∃Δ"
+@test chop(S("∀ϵ∃Δ"), head=2, tail=0) == "∃Δ"
+@test chop(S("∀ϵ∃Δ"), head=3, tail=0) == "Δ"
+@test chop(S("∀ϵ∃Δ"), head=4, tail=0) == ""
+@test chop(S("∀ϵ∃Δ"), head=5, tail=0) == ""
+@test chop(S("∀ϵ∃Δ"), head=1, tail=1) == "ϵ∃"
+@test chop(S("∀ϵ∃Δ"), head=2, tail=2) == ""
+@test chop(S("∀ϵ∃Δ"), head=3, tail=3) == ""
+@test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=-3, tail=3)
+@test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=3, tail=-3)
+@test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=-3, tail=-3)
 
 end # @testset
 


### PR DESCRIPTION
- close #38 
  - also mentioned at https://github.com/JuliaStrings/InlineStrings.jl/issues/5#issuecomment-1261955407
 
Before we were calculating the new "length" of the string accidentally assuming all "characters" were 1 codeunit and not adjusting this to consider "characters" that take more than 1 codeunit (possibly because of how the [`Base.chop(::AbstractString)` method](https://github.com/JuliaLang/julia/blob/41c2c7c5924f9c577983fdbd002b0bbfeb349601/base/strings/util.jl#L194-L198) delegates this final adjustment to the [`SubString` constructor](https://github.com/JuliaLang/julia/blob/41c2c7c5924f9c577983fdbd002b0bbfeb349601/base/strings/substring.jl#L37))

I _think_ this is now correct for strings with multi-byte "characters" anywhere in the string... but this stuff make my head hurt so i'm mostly relying on testcases for that and someone should double-check the logic 😅 