### PR TITLE
Add `chopprefix`/`chopsuffix` methods returning `InlineString`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -350,7 +350,7 @@ function Base.chop(s::InlineString; head::Integer = 0, tail::Integer = 1)
     return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), new_n))
 end
 
-if VERSION >= v"1.8"
+if isdefined(Base, :chopprefix)
 
 Base.chopprefix(s::InlineString1, prefix::AbstractString) = chopprefix(String3(s), prefix)
 function Base.chopprefix(s::InlineString, prefix::AbstractString)
@@ -379,6 +379,10 @@ end
     return Base.or_int(s, _oftype(typeof(s), new_n))
 end
 
+end # isdefined
+
+if isdefined(Base, :chopsuffix)
+
 Base.chopsuffix(s::InlineString1, suffix::AbstractString) = chopsuffix(String3(s), suffix)
 function Base.chopsuffix(s::InlineString, suffix::AbstractString)
     if !isempty(suffix) && endswith(s, suffix)
@@ -403,7 +407,7 @@ end
     return Base.or_int(s, _oftype(typeof(s), new_n))
 end
 
-end # if VERSION
+end # isdefined
 
 # used to zero out n lower bytes of an inline string
 clear_n_bytes(s, n) = Base.shl_int(Base.lshr_int(s, 8 * n), 8 * n)

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -350,6 +350,37 @@ function Base.chop(s::InlineString; head::Integer = 0, tail::Integer = 1)
     return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), new_n))
 end
 
+if VERSION >= v"1.8"
+
+Base.chopprefix(s::InlineString1, prefix::AbstractString) = chopprefix(String3(s), prefix)
+function Base.chopprefix(s::InlineString, prefix::AbstractString)
+    if !isempty(prefix) && startswith(s, prefix)
+        n = ncodeunits(s)
+        nprefix = ncodeunits(prefix)
+        new_n = n - nprefix
+        # `length` to call `nextind` for each "character" (not codeunit) in prefix
+        i = min(n + 1, max(nextind(s, firstindex(s), length(prefix)), 1))
+        s = clear_n_bytes(s, 1)           # clear out the length bits
+        s = Base.shl_int(s, (i - 1) * 8)  # clear out prefix
+        return Base.or_int(s, _oftype(typeof(s), new_n))
+    end
+    return s
+end
+
+Base.chopsuffix(s::InlineString1, suffix::AbstractString) = chopsuffix(String3(s), suffix)
+function Base.chopsuffix(s::InlineString, suffix::AbstractString)
+    if !isempty(suffix) && endswith(s, suffix)
+        n = ncodeunits(s)
+        nsuffix = ncodeunits(suffix)
+        new_n = n - nsuffix
+        s = clear_n_bytes(s, sizeof(typeof(s)) - new_n)
+        return Base.or_int(s, _oftype(typeof(s), new_n))
+    end
+    return s
+end
+
+end # if VERSION
+
 # used to zero out n lower bytes of an inline string
 clear_n_bytes(s, n) = Base.shl_int(Base.lshr_int(s, 8 * n), 8 * n)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,65 @@ S = InlineString15
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=3, tail=-3)
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=-3, tail=-3)
 
+@test chopprefix(abc, "a") === InlineString3("bc")
+@test chopprefix(abc, "bc") === abc
+@test chopprefix(abc, "abc") === InlineString3("")
+@test chopprefix(InlineString1("a"), "a") === InlineString3("")
+
+@test chopsuffix(abc, "a") === abc
+@test chopsuffix(abc, "bc") === InlineString3("a")
+@test chopsuffix(abc, "abc") === InlineString3("")
+@test chopsuffix(InlineString1("c"), "c") === InlineString3("")
+
+# chopprefix / chopsuffix tests copied from Base
+# https://github.com/JuliaLang/julia/blob/v1.8.2/test/strings/util.jl#L519-L564
+S = InlineString15
+for T in (String, InlineString)
+    @test chopprefix(S("fo∀\n"), T("bog")) == "fo∀\n"
+    @test chopprefix(S("fo∀\n"), T("\n∀foΔ")) == "fo∀\n"
+    @test chopprefix(S("fo∀\n"), T("∀foΔ")) == "fo∀\n"
+    @test chopprefix(S("fo∀\n"), T("f")) == "o∀\n"
+    @test chopprefix(S("fo∀\n"), T("fo")) == "∀\n"
+    @test chopprefix(S("fo∀\n"), T("fo∀")) == "\n"
+    @test chopprefix(S("fo∀\n"), T("fo∀\n")) == ""
+    @test chopprefix(S("\nfo∀"), T("bog")) == "\nfo∀"
+    @test chopprefix(S("\nfo∀"), T("\n∀foΔ")) == "\nfo∀"
+    @test chopprefix(S("\nfo∀"), T("\nfo∀")) == ""
+    @test chopprefix(S("\nfo∀"), T("\n")) == "fo∀"
+    @test chopprefix(S("\nfo∀"), T("\nf")) == "o∀"
+    @test chopprefix(S("\nfo∀"), T("\nfo")) == "∀"
+    @test chopprefix(S("\nfo∀"), T("\nfo∀")) == ""
+    @test chopprefix(S(""), T("")) == ""
+    @test chopprefix(S(""), T("asdf")) == ""
+    @test chopprefix(S(""), T("∃∃∃")) == ""
+    @test chopprefix(S("εfoo"), T("ε")) == "foo"
+    @test chopprefix(S("ofoε"), T("o")) == "foε"
+    @test chopprefix(S("∃∃∃∃"), T("∃")) == "∃∃∃"
+    @test chopprefix(S("∃∃∃∃"), T("")) == "∃∃∃∃"
+
+    @test chopsuffix(S("fo∀\n"), T("bog")) == "fo∀\n"
+    @test chopsuffix(S("fo∀\n"), T("\n∀foΔ")) == "fo∀\n"
+    @test chopsuffix(S("fo∀\n"), T("∀foΔ")) == "fo∀\n"
+    @test chopsuffix(S("fo∀\n"), T("\n")) == "fo∀"
+    @test chopsuffix(S("fo∀\n"), T("∀\n")) == "fo"
+    @test chopsuffix(S("fo∀\n"), T("o∀\n")) == "f"
+    @test chopsuffix(S("fo∀\n"), T("fo∀\n")) == ""
+    @test chopsuffix(S("\nfo∀"), T("bog")) == "\nfo∀"
+    @test chopsuffix(S("\nfo∀"), T("\n∀foΔ")) == "\nfo∀"
+    @test chopsuffix(S("\nfo∀"), T("\nfo∀")) == ""
+    @test chopsuffix(S("\nfo∀"), T("∀")) == "\nfo"
+    @test chopsuffix(S("\nfo∀"), T("o∀")) == "\nf"
+    @test chopsuffix(S("\nfo∀"), T("fo∀")) == "\n"
+    @test chopsuffix(S("\nfo∀"), T("\nfo∀")) == ""
+    @test chopsuffix(S(""), T("")) == ""
+    @test chopsuffix(S(""), T("asdf")) == ""
+    @test chopsuffix(S(""), T("∃∃∃")) == ""
+    @test chopsuffix(S("fooε"), T("ε")) == "foo"
+    @test chopsuffix(S("εofo"), T("o")) == "εof"
+    @test chopsuffix(S("∃∃∃∃"), T("∃")) == "∃∃∃"
+    @test chopsuffix(S("∃∃∃∃"), T("")) == "∃∃∃∃"
+end
+
 end # @testset
 
 const STRINGS = ["", "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -106,11 +106,17 @@ S = InlineString15
 @test chopprefix(abc, "bc") === abc
 @test chopprefix(abc, "abc") === InlineString3("")
 @test chopprefix(InlineString1("a"), "a") === InlineString3("")
+# Regex case
+@test chopprefix(InlineString15("∃∃∃b∃"), r"∃+") === InlineString15("b∃")
+@test chopprefix(InlineString1("a"), r".") === InlineString3("")
 
 @test chopsuffix(abc, "a") === abc
 @test chopsuffix(abc, "bc") === InlineString3("a")
 @test chopsuffix(abc, "abc") === InlineString3("")
 @test chopsuffix(InlineString1("c"), "c") === InlineString3("")
+# Regex case
+@test chopsuffix(InlineString15("∃b∃∃∃"), r"∃+") === InlineString15("∃b")
+@test chopsuffix(InlineString1("c"), r".") === InlineString3("")
 
 # chopprefix / chopsuffix tests copied from Base
 # https://github.com/JuliaLang/julia/blob/v1.8.2/test/strings/util.jl#L519-L564

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -102,6 +102,7 @@ S = InlineString15
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=3, tail=-3)
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=-3, tail=-3)
 
+if isdefined(Base, :chopprefix)
 @test chopprefix(abc, "a") === InlineString3("bc")
 @test chopprefix(abc, "bc") === abc
 @test chopprefix(abc, "abc") === InlineString3("")
@@ -109,7 +110,9 @@ S = InlineString15
 # Regex case
 @test chopprefix(InlineString15("∃∃∃b∃"), r"∃+") === InlineString15("b∃")
 @test chopprefix(InlineString1("a"), r".") === InlineString3("")
+end
 
+if isdefined(Base, :chopsuffix)
 @test chopsuffix(abc, "a") === abc
 @test chopsuffix(abc, "bc") === InlineString3("a")
 @test chopsuffix(abc, "abc") === InlineString3("")
@@ -117,7 +120,9 @@ S = InlineString15
 # Regex case
 @test chopsuffix(InlineString15("∃b∃∃∃"), r"∃+") === InlineString15("∃b")
 @test chopsuffix(InlineString1("c"), r".") === InlineString3("")
+end
 
+if isdefined(Base, :chopprefix) && isdefined(Base, :chopsuffix)
 # chopprefix / chopsuffix tests copied from Base
 # https://github.com/JuliaLang/julia/blob/v1.8.2/test/strings/util.jl#L519-L564
 S = InlineString15
@@ -166,6 +171,7 @@ for T in (String, InlineString)
     @test chopsuffix(S("∃∃∃∃"), T("∃")) == "∃∃∃"
     @test chopsuffix(S("∃∃∃∃"), T("")) == "∃∃∃∃"
 end
+end # isdefined
 
 end # @testset
 


### PR DESCRIPTION
- close #40
  - for reference, Base PR for these functions was https://github.com/JuliaLang/julia/pull/40995
- ~based on top of #39 (i.e. includes those commits) so PR#39 should go in first and i'll mark this as draft for now, although it's ready for review~