### PR TITLE
Support constructing from bytes buffer alone

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -152,7 +152,7 @@ function InlineString1(x::AbstractString)
     return Base.bitcast(InlineString1, codeunit(x, 1))    
 end
 
-function InlineString1(buf::AbstractVector{UInt8}, pos, len)
+function InlineString1(buf::AbstractVector{UInt8}, pos=1, len=length(buf))
     len == 1 || stringtoolong(InlineString1, len)
     return Base.bitcast(InlineString1, buf[pos])
 end
@@ -195,7 +195,7 @@ for T in (:InlineString3, :InlineString7, :InlineString15, :InlineString31, :Inl
         end
     end
 
-    @eval function $T(buf::AbstractVector{UInt8}, pos, len)
+    @eval function $T(buf::AbstractVector{UInt8}, pos=1, len=length(buf))
         blen = length(buf)
         blen < len && buftoosmall(len)
         len < sizeof($T) || stringtoolong($T, len)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,11 +34,25 @@ y = InlineString7(x)
 # https://discourse.julialang.org/t/having-trouble-implementating-a-tables-jl-row-table-when-using-badukgoweiqitools-dataframe-tbl-no-longer-works/63622/1
 @test promote_type(Union{}, String) == String
 
+# construction from bytes buffer
 # make sure we don't read past an end of a buffer
 buf = Vector{UInt8}("hey")
 x = InlineString7(buf, 1, 3)
 @test x == "hey"
 @test typeof(x) == InlineString7
+x = InlineString7(buf)
+@test x == "hey"
+@test typeof(x) == InlineString7
+@test_throws ArgumentError InlineString7(b"abcdefgh")
+
+buf = Vector{UInt8}("x")
+x = InlineString1(buf, 1, 1)
+@test x == "x"
+@test typeof(x) == InlineString1
+x = InlineString1(buf)
+@test x == "x"
+@test typeof(x) == InlineString1
+@test_throws ArgumentError InlineString1(b"xy")
 
 # https://github.com/JuliaData/WeakRefStrings.jl/issues/88
 @test InlineString(String1("a")) === String1("a")


### PR DESCRIPTION
Was there a reason not to support this and instead require a user to give `pos` and `len` arguments explicitly? 

I don't particularly have a use-case beyond having expected this to work having it tried it when developing locally...

Since someone can write 
```jl
julia> String([0x61, 0x62, 0x63])
"abc"
```
I thought it might make sense to be able to write
```jl
julia> String3([0x61, 0x62, 0x63])
"abc"
```
I think `length(buf)` is probably the correct default, e.g. to get
```julia
julia> String3([0x61, 0x62, 0x63, 0x64])
ERROR: ArgumentError: string too large (4) to convert to String3
Stacktrace:
 [1] stringtoolong(T::Type, n::Int64)
   @ InlineStrings ~/repos/InlineStrings.jl/src/InlineStrings.jl:264
 [2] String3(buf::Vector{UInt8}, pos::Int64, len::Int64)
   @ InlineStrings ~/repos/InlineStrings.jl/src/InlineStrings.jl:201
 [3] String3(buf::Vector{UInt8})
   @ InlineStrings ~/repos/InlineStrings.jl/src/InlineStrings.jl:199
 [4] top-level scope
   @ REPL[39]:1
```
(rather than e.g. just consuming as much of the buffer as would fit in the requested type)