### PR TITLE
Define `getindex(::InlineString, range)` to return InlineString

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -356,8 +356,8 @@ end
 end
 
 Base.getindex(s::InlineString1, r::AbstractUnitRange{<:Integer}) = getindex(InlineString3(s), r)
-Base.@propagate_inbounds function Base.getindex(s::T, r::AbstractUnitRange{<:Integer}) where {T <: InlineString}
-    isempty(r) && return T("")
+Base.@propagate_inbounds function Base.getindex(s::InlineString, r::AbstractUnitRange{<:Integer})
+    isempty(r) && return typeof(s)("")
     i = first(r)
     j = last(r)
     @boundscheck begin

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -684,14 +684,14 @@ function iterate_continued(s::InlineString, i::Int, u::UInt32)
     return reinterpret(Char, u), i
 end
 
-Base.@propagate_inbounds function Base.getindex(s::InlineString, i::Int)
+Base.@propagate_inbounds function Base.getindex(s::InlineString, i::Integer)
     b = codeunit(s, i)
     u = UInt32(b) << 24
     Base.between(b, 0x80, 0xf7) || return reinterpret(Char, u)
     return getindex_continued(s, i, u)
 end
 
-function getindex_continued(s::InlineString, i::Int, u::UInt32)
+function getindex_continued(s::InlineString, i::Integer, u::UInt32)
     if u < 0xc0000000
         # called from `getindex` which checks bounds
         @inbounds isvalid(s, i) && @goto ret

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -355,8 +355,10 @@ end
     return Base.or_int(Base.shl_int(s, (i - 1) * 8), _oftype(typeof(s), new_n))
 end
 
-Base.getindex(s::InlineString1, r::AbstractUnitRange{<:Integer}) = getindex(InlineString3(s), r)
-Base.@propagate_inbounds function Base.getindex(s::InlineString, r::AbstractUnitRange{<:Integer})
+Base.getindex(s::InlineString, r::AbstractUnitRange{<:Integer}) = getindex(s, Int(first(r)):Int(last(r)))
+
+Base.getindex(s::InlineString1, r::UnitRange{Int}) = getindex(InlineString3(s), r)
+Base.@propagate_inbounds function Base.getindex(s::InlineString, r::UnitRange{Int})
     isempty(r) && return typeof(s)("")
     i = first(r)
     j = last(r)

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -41,7 +41,7 @@ for sz in (1, 4, 8, 16, 32, 64, 128, 256)
         from a byte buffer with position and length (`$($nm)(buf, pos, len)`),
         from a pointer with optional length (`$($nm)(ptr, len)`)
         or built iteratively by starting with `x = $($nm)()` and calling
-        `x, overflowed = InlineStrings.addcodeunit(x, b::UInt8)` which returns a 
+        `x, overflowed = InlineStrings.addcodeunit(x, b::UInt8)` which returns a
         new $($nm) with the new codeunit `b` appended and an `overflowed` `Bool`
         value indicating whether too many codeunits have been appended for the
         fixed size. When constructed from a pointer, note that the `ptr` must
@@ -149,7 +149,7 @@ InlineString1(byte::UInt8=0x00) = Base.bitcast(InlineString1, byte)
 
 function InlineString1(x::AbstractString)
     sizeof(x) == 1 || stringtoolong(InlineString1, sizeof(x))
-    return Base.bitcast(InlineString1, codeunit(x, 1))    
+    return Base.bitcast(InlineString1, codeunit(x, 1))
 end
 
 function InlineString1(buf::AbstractVector{UInt8}, pos=1, len=length(buf))
@@ -349,7 +349,6 @@ end
 
 # `i`, `j` must be `isvalid` string indexes
 @inline function _subinlinestring(s::T, i::Integer, j::Integer) where {T <: InlineString}
-    n = ncodeunits(s)
     new_n = max(0, nextind(s, j) - i)                        # new ncodeunits
     jx = nextind(s, j) - 1                                   # last codeunit to keep
     s = clear_n_bytes(s, sizeof(typeof(s)) - jx)

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -356,7 +356,7 @@ end
 end
 
 Base.getindex(s::InlineString1, r::AbstractUnitRange{<:Integer}) = getindex(InlineString3(s), r)
-function Base.getindex(s::T, r::AbstractUnitRange{<:Integer}) where {T <: InlineString}
+Base.@propagate_inbounds function Base.getindex(s::T, r::AbstractUnitRange{<:Integer}) where {T <: InlineString}
     isempty(r) && return T("")
     i = first(r)
     j = last(r)
@@ -365,7 +365,7 @@ function Base.getindex(s::T, r::AbstractUnitRange{<:Integer}) where {T <: Inline
         @inbounds isvalid(s, i) || Base.string_index_err(s, i)
         @inbounds isvalid(s, j) || Base.string_index_err(s, j)
     end
-    return _subinlinestring(s, first(r), last(r))
+    return _subinlinestring(s, i, j)
 end
 
 Base.view(s::InlineString, r::AbstractUnitRange{<:Integer}) = getindex(s, r)

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -356,7 +356,8 @@ end
 end
 
 Base.getindex(s::InlineString1, r::AbstractUnitRange{<:Integer}) = getindex(InlineString3(s), r)
-function Base.getindex(s::InlineString, r::AbstractUnitRange{<:Integer})
+function Base.getindex(s::T, r::AbstractUnitRange{<:Integer}) where {T <: InlineString}
+    isempty(r) && return T("")
     i = first(r)
     j = last(r)
     @boundscheck begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -213,6 +213,40 @@ S = InlineString31
 @test strip(S("foobarfoo"), ('f','o')) === S("bar")
 @test strip(ispunct, S("¡Hola!")) === S("Hola")
 
+const SUBTYPES = (
+    InlineString1,
+    InlineString3,
+    InlineString7,
+    InlineString15,
+    InlineString31,
+    InlineString63,
+    InlineString127,
+    InlineString255,
+)
+
+# getindex
+for S in SUBTYPES
+    if S == InlineString1
+        x = S("x")
+        @test x[1] == 'x'
+        @test x[1:1] isa InlineString3
+        @test x[1:1] === view(x, 1:1) === InlineString3(x)
+        @test x[2:1] === view(x, 2:1) === InlineString3("")
+        @test_throws BoundsError x[2]
+    else
+        abc = S("abc")
+        @test abc[1] == 'a'
+        @test abc[1:2] isa S
+        @test abc[1:2] === view(abc, 1:2) === S("ab")
+        @test abc[2:1] === view(abc, 2:1) === S("")
+        @test_throws BoundsError abc[4]
+        @test_throws BoundsError abc[1:4]
+        @test S("÷2")[1:3] === S("÷2")
+        @test_throws StringIndexError S("÷2")[2]
+        @test_throws StringIndexError S("÷2")[1:2]
+    end
+end
+
 end # @testset
 
 const STRINGS = ["", "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255]
@@ -237,6 +271,9 @@ const INLINES = map(InlineString, STRINGS)
         @test string(x) == string(y)
         @test join([x, x]) == join([y, y])
         @test reverse(x) == reverse(y)
+        y != "" && @test x[1] == y[1]
+        y != "" && @test x[1:1] == y[1:1]
+        y != "" && @test view(x, 1:1) == view(y, 1:1)
         y != "" && @test startswith(x, "a") == startswith(y, "a")
         y != "" && @test endswith(x, "a") == endswith(y, "a")
         y != "" && @test findfirst(==(x[1]), x) === findfirst(==(x[1]), y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,6 +239,7 @@ for S in SUBTYPES
         @test abc[1:2] isa S
         @test abc[1:2] === view(abc, 1:2) === S("ab")
         @test abc[2:1] === view(abc, 2:1) === S("")
+        @test abc[Base.OneTo(2)] === S("ab")
         @test_throws BoundsError abc[4]
         @test_throws BoundsError abc[1:4]
         @test S("÷2")[1:3] === S("÷2")
@@ -434,7 +435,7 @@ end
 @testset "inlinestrings" begin
 
     @test inlinestrings([]) == []
-    
+
     x = inlinestrings("$i" for i in (1, 10, 100))
     @test eltype(x) === String3
     @test x == ["1", "10", "100"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -272,6 +272,7 @@ const INLINES = map(InlineString, STRINGS)
         @test join([x, x]) == join([y, y])
         @test reverse(x) == reverse(y)
         y != "" && @test x[1] == y[1]
+        y != "" && @test x[Int8(1)] == y[Int8(1)]
         y != "" && @test x[1:1] == y[1:1]
         y != "" && @test view(x, 1:1) == view(y, 1:1)
         y != "" && @test startswith(x, "a") == startswith(y, "a")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,17 @@
 using Test, InlineStrings, Parsers, Serialization, Random
 import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED, INVALID_DELIMITER, INVALID_QUOTED_FIELD, ESCAPED_STRING, NEWLINE, SUCCESS, peekbyte, incr!, checksentinel, checkdelim, checkcmtemptylines
 
+const SUBTYPES = (
+    InlineString1,
+    InlineString3,
+    InlineString7,
+    InlineString15,
+    InlineString31,
+    InlineString63,
+    InlineString127,
+    InlineString255,
+)
+
 @testset "InlineString basics" begin
 
 y = "abcdef"
@@ -212,17 +223,6 @@ S = InlineString31
 @test strip(S("foobarfoo"), ['f','o']) === S("bar")
 @test strip(S("foobarfoo"), ('f','o')) === S("bar")
 @test strip(ispunct, S("¡Hola!")) === S("Hola")
-
-const SUBTYPES = (
-    InlineString1,
-    InlineString3,
-    InlineString7,
-    InlineString15,
-    InlineString31,
-    InlineString63,
-    InlineString127,
-    InlineString255,
-)
 
 # getindex
 for S in SUBTYPES


### PR DESCRIPTION
This is another case where we could be keeping things as `InlineString` rather than returning a `SubString{InlineString}` (like `chop`, `chomp`, `strip` etc) (xref #5)

...but i don't love the (worse than linear) slowdown i'm seeing for larger InlineString types 

I guess it makes sense since we're doing more work to construct a new InlineString (two `nextind` calls and then several bit-shifts) than the work involved in creating a SubString (which is basically a single `nextind` call)?

Micro-benchmark
```jl
      for S in (
           InlineString3, InlineString7, InlineString15, InlineString31,
           InlineString63, InlineString127, InlineString255,
       )
           str = S(repeat("x", sizeof(S)-1))
           ix = (firstindex(str) + 1):(lastindex(str) - 1)
           @btime $str[$ix]
       end
```
       
On `main` (returning `SubString`)
```julia
  14.194 ns (0 allocations: 0 bytes)
  11.720 ns (0 allocations: 0 bytes)
  16.658 ns (0 allocations: 0 bytes)
  18.681 ns (0 allocations: 0 bytes)
  29.732 ns (0 allocations: 0 bytes)
  57.562 ns (0 allocations: 0 bytes)
  109.481 ns (0 allocations: 0 bytes)
```
On this branch (returning `InlineString`)
```julia
  10.218 ns (0 allocations: 0 bytes)
  12.930 ns (0 allocations: 0 bytes)
  14.570 ns (0 allocations: 0 bytes)
  29.313 ns (0 allocations: 0 bytes)
  98.969 ns (0 allocations: 0 bytes)
  328.744 ns (0 allocations: 0 bytes)
  1.283 μs (0 allocations: 0 bytes)
```

---

There's also `getindex(str, vec)` that allows selecting non-contiguous elements... so maybe if we add this we should add that too? (currently returns `SubString`)