### PR TITLE
Drop support for Julia versions before LTS version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.3'
+          - '1.6' # LTS version
           - '1' # automatically expands to the latest stable 1.x release of Julia
           - 'nightly'
         os:

--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 Parsers = "2"
-julia = "1.3"
+julia = "1.6"
 
 [targets]
 test = ["Test", "Random", "Serialization"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # InlineStrings
 
 [![CI](https://github.com/JuliaData/InlineStrings.jl/workflows/CI/badge.svg)](https://github.com/JuliaData/InlineStrings.jl/actions?query=workflow%3ACI)
@@ -19,7 +18,7 @@ julia> using Pkg; Pkg.add("InlineStrings")
 
 ## Project Status
 
-The package is tested against Julia `1.6` and `nightly` on Linux, OS X, and Windows.
+The package is tested against the latest Julia `1.x` release, the long-term support release `1.6`, and `nightly` on Linux, OS X, and Windows.
 
 ## Contributing and Questions
 


### PR DESCRIPTION
- Julia versions pre-1.6 are no longer maintained, and v1.3 was causing issues over in #44, so this new versions of this package won't support pre-1.6 versions either.