### PR TITLE
Simplify converting to `Vector{UInt8}`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -132,6 +132,9 @@ function Base.Symbol(x::T) where {T <: InlineString}
         (Ref{T}, Int), ref, sizeof(x))
 end
 
+Base.Vector{UInt8}(s::InlineString) = Vector{UInt8}(codeunits(s))
+Base.Array{UInt8}(s::InlineString) = Vector{UInt8}(codeunits(s))
+
 # add a codeunit to end of string method
 function addcodeunit(x::T, b::UInt8) where {T <: InlineString}
     if T === InlineString1


### PR DESCRIPTION
- Saves an allocation compared to the current Base method which first calls `String(s)`
- related to #5 
- covered by existing tests

before:
```jl
julia> s = String31("abcd_efgh")
"abcd_efgh"

julia> @time Vector{UInt8}(s);
  0.000012 seconds (2 allocations: 96 bytes)
```
now:
```jl
julia> @time Vector{UInt8}(s);
  0.000011 seconds (1 allocation: 64 bytes)
```