### PR TITLE
Add string macros

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -66,10 +66,7 @@ for sz in (1, 4, 8, 16, 32, 64, 128, 256)
         """
         macro $macro_nm(ex)
             T = InlineStringType($(max(1,sz - 1)))
-            s = T(unescape_string(ex))
-            quote
-                $s
-            end
+            T(unescape_string(ex))
         end
 
         export $at_macro_nm
@@ -297,25 +294,13 @@ InlineString(x::AbstractString)::InlineStringTypes = (InlineStringType(ncodeunit
 
 """
     inline"string"
-    inline"string"N
 
 Macro to create an [`InlineString`](@ref).
-Optionally specify `N` to create an `InlineString` of at least `N` codeunits.
 """
 macro inline_str(ex)
-    s = InlineString(unescape_string(ex))
-    quote
-        $s
-    end
+    InlineString(unescape_string(ex))
 end
 
-macro inline_str(ex, n)
-    T = InlineStringType(n)
-    s = T(unescape_string(ex))
-    quote
-        $s
-    end
-end
 
 (==)(x::T, y::T) where {T <: InlineString} = Base.eq_int(x, y)
 function ==(x::String, y::T) where {T <: InlineString}

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -24,6 +24,8 @@ abstract type InlineString <: AbstractString end
 for sz in (1, 4, 8, 16, 32, 64, 128, 256)
     nm = Symbol(:String, max(1, sz - 1))
     nma = Symbol(:InlineString, max(1, sz - 1))
+    macro_nm = Symbol(:inline, max(1, sz - 1), :_str)
+    at_macro_nm = Symbol("@", macro_nm)
     @eval begin
         """
             $($nm)(str::AbstractString)
@@ -56,6 +58,21 @@ for sz in (1, 4, 8, 16, 32, 64, 128, 256)
         const $nma = $nm
         export $nm
         export $nma
+
+        """
+            inline$($(max(1, sz - 1)))"string"
+
+        Macro to create a [`$($nm)`](@ref) with a fixed size of $($sz) bytes.
+        """
+        macro $macro_nm(ex)
+            T = InlineStringType($(max(1,sz - 1)))
+            s = T(unescape_string(ex))
+            quote
+                $s
+            end
+        end
+
+        export $at_macro_nm
     end
 end
 

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -5,6 +5,7 @@ import Base: ==
 using Parsers
 
 export InlineString, InlineStringType, inlinestrings
+export @Inline_str
 
 """
     InlineString
@@ -276,6 +277,28 @@ end
 
 InlineString(x::InlineString) = x
 InlineString(x::AbstractString)::InlineStringTypes = (InlineStringType(ncodeunits(x)))(x)
+
+"""
+    Inline"string"
+    Inline"string"N
+
+Macro to create an [`InlineString`](@ref).
+Optionally specify `N` to create an `InlineString` of at least `N` codeunits.
+"""
+macro Inline_str(ex)
+    s = unescape_string(ex)
+    quote
+        InlineString($s)
+    end
+end
+
+macro Inline_str(ex, n)
+    s = unescape_string(ex)
+    T = InlineStringType(n)
+    quote
+        $T($s)
+    end
+end
 
 (==)(x::T, y::T) where {T <: InlineString} = Base.eq_int(x, y)
 function ==(x::String, y::T) where {T <: InlineString}

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -5,7 +5,7 @@ import Base: ==
 using Parsers
 
 export InlineString, InlineStringType, inlinestrings
-export @Inline_str
+export @inline_str
 
 """
     InlineString
@@ -279,24 +279,24 @@ InlineString(x::InlineString) = x
 InlineString(x::AbstractString)::InlineStringTypes = (InlineStringType(ncodeunits(x)))(x)
 
 """
-    Inline"string"
-    Inline"string"N
+    inline"string"
+    inline"string"N
 
 Macro to create an [`InlineString`](@ref).
 Optionally specify `N` to create an `InlineString` of at least `N` codeunits.
 """
-macro Inline_str(ex)
-    s = unescape_string(ex)
+macro inline_str(ex)
+    s = InlineString(unescape_string(ex))
     quote
-        InlineString($s)
+        $s
     end
 end
 
-macro Inline_str(ex, n)
-    s = unescape_string(ex)
+macro inline_str(ex, n)
     T = InlineStringType(n)
+    s = T(unescape_string(ex))
     quote
-        $T($s)
+        $s
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,13 +488,13 @@ end
 end
 
 @testset "macros" begin
-    x = Inline"This is a macro test"
+    x = inline"This is a macro test"
     @test String(x) == "This is a macro test"
     @test typeof(x) == String31
-    y = Inline"This is macro test"255
+    y = inline"This is macro test"255
     @test typeof(y) == String255
     for n in (2 .^(0:8) .- 1)
-        z = eval(quote @Inline_str "This is macro test" $n end)
+        z = eval(quote @inline_str "a" $n end)
         T = InlineStrings.InlineStringType(n)
         @test typeof(z) == T
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,4 +498,12 @@ end
         T = InlineStrings.InlineStringType(n)
         @test typeof(z) == T
     end
+    @test typeof(inline1"a") == String1
+    @test typeof(inline3"a") == String3
+    @test typeof(inline7"a") == String7
+    @test typeof(inline15"a") == String15
+    @test typeof(inline31"a") == String31
+    @test typeof(inline63"a") == String63
+    @test typeof(inline127"a") == String127
+    @test typeof(inline255"a") == String255
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -491,13 +491,6 @@ end
     x = inline"This is a macro test"
     @test String(x) == "This is a macro test"
     @test typeof(x) == String31
-    y = inline"This is macro test"255
-    @test typeof(y) == String255
-    for n in (2 .^(0:8) .- 1)
-        z = eval(quote @inline_str "a" $n end)
-        T = InlineStrings.InlineStringType(n)
-        @test typeof(z) == T
-    end
     @test typeof(inline1"a") == String1
     @test typeof(inline3"a") == String3
     @test typeof(inline7"a") == String7

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -486,3 +486,16 @@ end
         @test InlineString(x) == String(x)
     end
 end
+
+@testset "macros" begin
+    x = Inline"This is a macro test"
+    @test String(x) == "This is a macro test"
+    @test typeof(x) == String31
+    y = Inline"This is macro test"255
+    @test typeof(y) == String255
+    for n in (2 .^(0:8) .- 1)
+        z = eval(quote @Inline_str "This is macro test" $n end)
+        T = InlineStrings.InlineStringType(n)
+        @test typeof(z) == T
+    end
+end


### PR DESCRIPTION
This creates a string macro to aid in inline string construction.

```julia
julia> using InlineStrings

julia> inline"Hello world"
"Hello world"

julia> typeof(ans)
String15

julia> inline"Hello world"31
"Hello world"

julia> typeof(ans)
String31

julia> @allocated inline"This is a string macro"
0

julia> @allocated inline"This is a string macro"31
0

julia> @allocated InlineString("This is not a string macro")
48

julia> @allocated String31("This is not a string macro")
0

julia> inline"String interpolation does not work: $x"
"String interpolation does not work: \$x"
```