### PR TITLE
Restore ability to parse to `Result{Any}`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -820,7 +820,7 @@ function Parsers.xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos
     if overflowed
         code |= Parsers.OVERFLOW
     end
-    return Parsers.Result{T}(code, res.tlen, x)
+    return Parsers.Result{S}(code, res.tlen, x)
 end
 
 ## InlineString sorting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -392,6 +392,16 @@ res = Parsers.xparse(InlineString1, "ab")
 res = Parsers.xparse(InlineString1, "b")
 @test res.val === InlineString("b")
 
+# Parse to a `Result{Any}`
+# https://github.com/JuliaData/CSV.jl/issues/1033
+buf = b"abc"
+pos = 1
+len = length(buf)
+opts = Parsers.Options()
+res = Parsers.xparse(InlineString7, buf, pos, len, opts, Any)
+@test res isa Parsers.Result{Any}
+@test res.val == "abc"
+
 end # @testset
 
 @testset "InlineString Serialization symmetry" begin


### PR DESCRIPTION
- Fix https://github.com/JuliaData/CSV.jl/issues/1033
- Follow-up to https://github.com/JuliaStrings/InlineStrings.jl/pull/49