### PR TITLE
Add `show` method containing type info

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -150,6 +150,13 @@ end
 Base.Vector{UInt8}(s::InlineString) = Vector{UInt8}(codeunits(s))
 Base.Array{UInt8}(s::InlineString) = Vector{UInt8}(codeunits(s))
 
+Base.show(io::IO, ::MIME"text/plain", s::InlineString) = Base.print_quoted(io, s)
+function Base.show(io::IO, s::InlineString)  # So `repr` shows how to recreate `s`
+    print(io, typeof(s), "(")
+    Base.print_quoted(io, s)
+    print(io, ")")
+end
+
 # add a codeunit to end of string method
 function addcodeunit(x::T, b::UInt8) where {T <: InlineString}
     if T === InlineString1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -500,3 +500,15 @@ end
     @test typeof(inline127"a") == String127
     @test typeof(inline255"a") == String255
 end
+
+@testset "print/show/repr" begin
+    s = InlineString7("abc")
+    # printing
+    @test "$(s)x" == "abcx"
+    @test sprint(print, s) == sprint(print, String(s)) == "abc"
+    # in the repl
+    @test sprint(show, MIME("text/plain"), s) == sprint(show, MIME("text/plain"), String(s)) == "\"abc\""
+    # repr
+    @test sprint(show, s) == "String7(\"abc\")"
+    @test eval(Meta.parse(repr(s))) === s
+end


### PR DESCRIPTION
- so e.g. `repr(s)` shows how to construct `s`
  ```
  julia> s = String3("abc");

  julia> println(repr(s))
  String3("abc")
  ```