### PR TITLE
ensure proper writing of codeunits

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "InlineStrings"
 uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
 authors = ["Jacob Quinn <quinn.jacobd@gmail.com> and contributors"]
-version = "1.3.0"
+version = "1.3.1"
 
 [deps]
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -337,6 +337,15 @@ function Base.write(io::IO, x::T) where {T <: InlineString}
     end
 end
 
+# without this method the fallback will try to write more than the codeunits
+function Base.write(io::IO, x::Base.CodeUnits{UInt8,<:InlineString})
+    s = 0
+    for j ∈ 1:ncodeunits(x.s)
+        s += write(io, codeunit(x.s, j))
+    end
+    s
+end
+
 function Base.read(s::IO, ::Type{T}) where {T <: InlineString}
     return read!(s, Ref{T}())[]::T
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -127,6 +127,12 @@ S = InlineString15
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=3, tail=-3)
 @test_throws ArgumentError chop(S("∀ϵ∃Δ"), head=-3, tail=-3)
 
+# check that writing code units works as expected
+io = IOBuffer()
+cu = codeunits(InlineString("hello"))
+@test write(io, cu) == 5
+@test take!(io) == codeunits("hello")
+
 if isdefined(Base, :chopprefix)
 @test chopprefix(abc, "a") === InlineString3("bc")
 @test chopprefix(abc, "bc") === abc


### PR DESCRIPTION
There is a really nasty fallback for writing `codeunits` in Base:
```julia
write(io::IO, s::CodeUnits) = write(io, s.s)
```
what this means for `InlineString` is that it is writing the canonical binary representation of the `InlineString`, *not* the code units that are correctly returned by `codeunits`.  This leads to confusing disasters like [this](https://gitlab.com/ExpandingMan/Parquet2.jl/-/issues/22).

This is a good demonstration of why it's really bad not to have a formal `AbstractString` interface.  We really ought to open an issue in `Base` but it might take some background research to open an intelligent and actionable issue.