### PR TITLE
Allow concatenating small InlineStrings to return an InlineString

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -649,7 +649,7 @@ summed_type(::Type{InlineString15}, ::Type{InlineString1}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString3}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString7}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString15}) = InlineString31
-summed_type(a::Type{<:SmallInlineString}, b::Type{<:SmallInlineString}) = summed_type(b, a)
+summed_type(a::Type{<:SmallInlineStrings}, b::Type{<:SmallInlineStrings}) = summed_type(b, a)
 
 function Base.repeat(x::T, r::Integer) where {T <: InlineString}
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -649,7 +649,7 @@ summed_type(::Type{InlineString15}, ::Type{InlineString1}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString3}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString7}) = InlineString31
 summed_type(::Type{InlineString15}, ::Type{InlineString15}) = InlineString31
-summed_type(a::Type{<:InlineString}, b::Type{<:InlineString}) = summed_type(b, a)
+summed_type(a::Type{<:SmallInlineString}, b::Type{<:SmallInlineString}) = summed_type(b, a)
 
 function Base.repeat(x::T, r::Integer) where {T <: InlineString}
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -624,8 +624,6 @@ const _SmallerInlineStrings = Union{InlineString1, InlineString3, InlineString7}
 Base.string(a::_SmallerInlineStrings, b::_SmallerInlineStrings, c::_SmallerInlineStrings) =
     _string(_string(a, b), c)
 const _SmallestInlineStrings = Union{InlineString1, InlineString3}
-Base.string(a::_SmallestInlineStrings, b::_SmallestInlineStrings, c::_SmallestInlineStrings) =
-    _string(_string(a, b), c)
 Base.string(a::_SmallestInlineStrings, b::_SmallestInlineStrings, c::_SmallestInlineStrings, d::_SmallestInlineStrings) =
     _string(_string(_string(a, b), c), d)
 

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -620,8 +620,14 @@ Base.string(a::BaseStrs, b::BaseStrs, c::InlineString) = _string(a, b, c)
 end
 
 # For more and/or bigger InlineStrings creating a `Base.String` is faster
-const TinyInlineStrings = Union{InlineString1, InlineString3, InlineString7}
-Base.string(a::TinyInlineStrings, b::TinyInlineStrings, c::TinyInlineStrings) = _string(_string(a, b), c)
+const _SmallerInlineStrings = Union{InlineString1, InlineString3, InlineString7}
+Base.string(a::_SmallerInlineStrings, b::_SmallerInlineStrings, c::_SmallerInlineStrings) =
+    _string(_string(a, b), c)
+const _SmallestInlineStrings = Union{InlineString1, InlineString3}
+Base.string(a::_SmallestInlineStrings, b::_SmallestInlineStrings, c::_SmallestInlineStrings) =
+    _string(_string(a, b), c)
+Base.string(a::_SmallestInlineStrings, b::_SmallestInlineStrings, c::_SmallestInlineStrings, d::_SmallestInlineStrings) =
+    _string(_string(_string(a, b), c), d)
 
 # Only benefit from keeping the small-ish strings as InlineStrings
 function _string(a::Ta, b::Tb) where {Ta <: SmallInlineStrings, Tb <: SmallInlineStrings}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -351,7 +351,7 @@ end
 
 @testset "`string` / `*`" begin
     # Check `string` overload handles `String1` being concat with other small InlineStrings,
-    # because it's easiest to mis-handle `String1` as it doesn't have a length byte.
+    # because it is easy to mishandle `String1` as it doesn't have a length byte.
     a = "a"
     @test String1(a) * String1(a) == a * a
     @test String1(a) * String1(a) isa InlineString3
@@ -363,12 +363,12 @@ end
     @test String1(a) * String15(b) == a * b
     @test String1(a) * String15(b) isa InlineString31
     @test String1(a) * String3(b) * String7(b) == a * b * b
-    @test String1(a) * String3(b) * String7(b) isa String15
+    @test String1(a) * String3(b) * String7(b) isa InlineString15
     # Check some other combination of small inline strings also work as expected
-    @test String3(a) * String7(b) == a * b * b
-    @test String3(a) * String7(b) isa String15
+    @test String3(a) * String7(b) == a * b
+    @test String3(a) * String7(b) isa InlineString15
     @test String3(a) * String3(b) * String7(b) == a * b * b
-    @test String3(a) * String3(b) * String7(b) isa String15
+    @test String3(a) * String3(b) * String7(b) isa InlineString15
 end
 
 @testset "InlineString parsing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,7 +69,7 @@ x = InlineString1(buf)
 @test InlineString(String1("a")) === String1("a")
 
 # https://github.com/JuliaData/InlineStrings.jl/issues/2
-@test string.(AbstractString[]) == AbstractString[]
+@test eltype(string.(AbstractString[])) == AbstractString
 
 # https://github.com/JuliaData/InlineStrings.jl/issues/8
 # construction from pointer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -69,8 +69,7 @@ x = InlineString1(buf)
 @test InlineString(String1("a")) === String1("a")
 
 # https://github.com/JuliaData/InlineStrings.jl/issues/2
-x = InlineString("hey")
-@test typeof(string(x)) == String
+@test string.(AbstractString[]) == AbstractString[]
 
 # https://github.com/JuliaData/InlineStrings.jl/issues/8
 # construction from pointer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -276,6 +276,7 @@ const INLINES = map(InlineString, STRINGS)
         @test Array{UInt8}(x) == Array{UInt8}(y)
         @test isascii(x) == isascii(y)
         @test x * x == y * y
+        @test x * x * x == y * y * y
         @test x^5 == y^5
         @test string(x) == string(y)
         @test join([x, x]) == join([y, y])
@@ -346,6 +347,28 @@ const INLINES = map(InlineString, STRINGS)
         @test unsafe_string(Base.unsafe_convert(Ptr{Int8}, Base.cconvert(Ptr{Int8}, x))) == y
         @test unsafe_string(Base.unsafe_convert(Cstring, Base.cconvert(Cstring, x))) == y
     end
+end
+
+@testset "`string` / `*`" begin
+    # Check `string` overload handles `String1` being concat with other small InlineStrings,
+    # because it's easiest to mis-handle `String1` as it doesn't have a length byte.
+    a = "a"
+    @test String1(a) * String1(a) == a * a
+    @test String1(a) * String1(a) isa InlineString3
+    b = "bb"
+    @test String1(a) * String3(b) == a * b
+    @test String1(a) * String3(b) isa InlineString7
+    @test String1(a) * String7(b) == a * b
+    @test String1(a) * String7(b) isa InlineString15
+    @test String1(a) * String15(b) == a * b
+    @test String1(a) * String15(b) isa InlineString31
+    @test String1(a) * String3(b) * String7(b) == a * b * b
+    @test String1(a) * String3(b) * String7(b) isa String15
+    # Check some other combination of small inline strings also work as expected
+    @test String3(a) * String7(b) == a * b * b
+    @test String3(a) * String7(b) isa String15
+    @test String3(a) * String3(b) * String7(b) == a * b * b
+    @test String3(a) * String3(b) * String7(b) isa String15
 end
 
 @testset "InlineString parsing" begin


### PR DESCRIPTION
- closes #58 
- now string concatenation `*` / `string` return an `InlineString` in some cases which give a performance improvment
    - the `Base.*` / `Base.string` API does not require us to return a `Base.String` (just an `AbstractString`)
        ```julia
        help?> *
        search: *
        
          *(s::Union{AbstractString, AbstractChar}, t::Union{AbstractString, AbstractChar}...) -> AbstractString
        
          Concatenate strings and/or characters, producing a String. This is equivalent to calling the string function on the
          arguments. Concatenation of built-in string types always produces a value of type String but other string types may choose
          to return a string of a different type as appropriate.
        ```

### Micro-benchmarks

```julia
using InlineStrings
using BenchmarkTools

s1 = InlineString1("a")
s3 = InlineString3("bb")
s7 = InlineString7("ccc")
s15 = InlineString15("dddd")

for s in (s1, s3, s7, s15)
    println(typeof(s))
    @btime $s * $s
    @btime $s * $s * $s
    @btime $s * $s * $s * $s
    @btime $s * $s * $s * $s * $s
end
```

#### Now (this PR)
```julia
String1
  2.125 ns (0 allocations: 0 bytes)
  2.125 ns (0 allocations: 0 bytes)
  2.084 ns (0 allocations: 0 bytes)
  7.125 ns (1 allocation: 24 bytes)
String3
  2.083 ns (0 allocations: 0 bytes)
  2.416 ns (0 allocations: 0 bytes)
  5.500 ns (0 allocations: 0 bytes)
  14.822 ns (1 allocation: 32 bytes)
String7
  2.416 ns (0 allocations: 0 bytes)
  4.500 ns (0 allocations: 0 bytes)
  19.163 ns (1 allocation: 32 bytes)
  22.234 ns (1 allocation: 32 bytes)
String15
  3.958 ns (0 allocations: 0 bytes)
  16.992 ns (1 allocation: 32 bytes)
  20.436 ns (1 allocation: 40 bytes)
  23.803 ns (1 allocation: 40 bytes)
```
#### Before (v1.3.2)
```julia
String1
  6.791 ns (1 allocation: 24 bytes)
  6.958 ns (1 allocation: 24 bytes)
  7.083 ns (1 allocation: 24 bytes)
  40.825 ns (6 allocations: 104 bytes)
String3
  9.844 ns (1 allocation: 24 bytes)
  11.678 ns (1 allocation: 24 bytes)
  13.263 ns (1 allocation: 32 bytes)
  48.963 ns (6 allocations: 112 bytes)
String7
  12.638 ns (1 allocation: 24 bytes)
  16.073 ns (1 allocation: 32 bytes)
  19.163 ns (1 allocation: 32 bytes)
  56.572 ns (6 allocations: 112 bytes)
String15
  13.597 ns (1 allocation: 32 bytes)
  16.951 ns (1 allocation: 32 bytes)
  20.416 ns (1 allocation: 40 bytes)
  59.070 ns (6 allocations: 200 bytes)
```

Run on v1.8.4:
```julia
julia> versioninfo()
Julia Version 1.8.4
Commit 00177ebc4fc (2022-12-23 21:32 UTC)
Platform Info:
  OS: macOS (arm64-apple-darwin21.5.0)
  CPU: 10 × Apple M1 Max
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-13.0.1 (ORCJIT, apple-m1)
  Threads: 1 on 8 virtual cores
```