### PR TITLE
improve printing for homogenous arrays

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -176,9 +176,13 @@ Base.Array{UInt8}(s::InlineString) = Vector{UInt8}(codeunits(s))
 
 Base.show(io::IO, ::MIME"text/plain", s::InlineString) = Base.print_quoted(io, s)
 function Base.show(io::IO, s::InlineString)  # So `repr` shows how to recreate `s`
-    print(io, typeof(s), "(")
-    Base.print_quoted(io, s)
-    print(io, ")")
+    if get(io, :typeinfo, Any) === typeof(s)
+        Base.print_quoted(io, s)
+    else
+        print(io, typeof(s), "(")
+        Base.print_quoted(io, s)
+        print(io, ")")
+    end
 end
 
 # add a codeunit to end of string method

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -558,4 +558,7 @@ end
     # repr
     @test sprint(show, s) == "String7(\"abc\")"
     @test eval(Meta.parse(repr(s))) === s
+
+    @test repr(String31["foo", "bar"]) == "String31[\"foo\", \"bar\"]"
+    @test repr(InlineString[inline1"a", inline15"a"]) == "InlineString[String1(\"a\"), String15(\"a\")]"
 end


### PR DESCRIPTION
This came up on Slack. Makes arrays of `InlineString`s a bit easier to
read.
