### PR TITLE
Fixed method ambiguities for `Base.unsafe_convert()`, `Base.lstrip`, and `Base.rstrip`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -482,6 +482,9 @@ end
     return Base.or_int(s, _oftype(typeof(s), new_n))
 end
 
+throw_strip_argument_error() =
+    throw(ArgumentError("Both arguments are strings. The second argument should be a `Char` or collection of `Char`s"))
+
 Base.lstrip(f, s::InlineString1) = lstrip(f, InlineString3(s))
 function Base.lstrip(f, s::InlineString)
     nc = 0
@@ -496,6 +499,9 @@ function Base.lstrip(f, s::InlineString)
     end
     return nc == 0 ? s : _chopprefix(s, nc, len)
 end
+
+Base.lstrip(::AbstractString, ::InlineString) = throw_strip_argument_error()
+Base.lstrip(::AbstractString, ::InlineString1) = throw_strip_argument_error()
 
 if isdefined(Base, :chopsuffix)
 
@@ -537,6 +543,9 @@ function Base.rstrip(f, s::InlineString)
     end
     return nc == 0 ? s : _chopsuffix(s, nc)
 end
+
+Base.rstrip(::AbstractString, ::InlineString) = throw_strip_argument_error()
+Base.rstrip(::AbstractString, ::InlineString1) = throw_strip_argument_error()
 
 Base.chomp(s::InlineString1) = chomp(String3(s))
 function Base.chomp(s::InlineString)

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -168,6 +168,10 @@ Base.unsafe_convert(::Type{Ptr{UInt8}}, x::Ref{T}) where {T <: InlineString} =
     Ptr{UInt8}(pointer_from_objref(x))
 Base.unsafe_convert(::Type{Ptr{Int8}}, x::Ref{T}) where {T <: InlineString} =
     Ptr{Int8}(pointer_from_objref(x))
+# Resolve method ambiguities
+Base.unsafe_convert(P::Type{Ptr{UInt8}}, x::Ptr{<:InlineString}) = convert(P, x)
+Base.unsafe_convert(P::Type{Ptr{Int8}}, x::Ptr{<:InlineString}) = convert(P, x)
+
 Base.unsafe_convert(::Type{Cstring}, s::Ref{T}) where {T <: InlineString} =
     Cstring(Base.unsafe_convert(Ptr{Cchar}, s))
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -210,12 +210,16 @@ S = InlineString7
 @test rstrip(isnumeric, S("abc0123")) === S("abc")
 @test rstrip(S("ello"), ['e','o']) === S("ell")
 @test rstrip(InlineString1("x")) === InlineString3("x")
+@test_throws ArgumentError rstrip("test", S(" a b c "))
+@test_throws ArgumentError rstrip("test", InlineString1("x"))
 
 @test lstrip(S(" a b c ")) isa S
 @test lstrip(S(" a b c ")) === S("a b c ")
 @test lstrip(isnumeric, S("0123abc")) === S("abc")
 @test lstrip(S("ello"), ['e','o']) === S("llo")
 @test lstrip(InlineString1("x")) === InlineString3("x")
+@test_throws ArgumentError lstrip("test", S(" a b c "))
+@test_throws ArgumentError lstrip("test", InlineString1("x"))
 
 @test strip(InlineString1("x")) === InlineString3("x")
 S = InlineString3


### PR DESCRIPTION
This doesn't fully solve #64, but it does solve two ambiguities: those between InlineStrings
```julia
unsafe_convert(::Type{Ptr{Int8}}}, x::Ref{T}) where T<:InlineString
unsafe_convert(::Type{Ptr{UInt8}}}, x::Ref{T}) where T<:InlineString
```
and Julia Base
```julia
unsafe_convert(::Type{P}, x::Ptr) where P<:Ptr
```


