### PR TITLE
remove some unnecessary `string` overloads

### DIFF
--- a/.github/workflows/Invalidations.yml
+++ b/.github/workflows/Invalidations.yml
@@ -30,11 +30,13 @@ jobs:
     - uses: julia-actions/julia-buildpkg@v1
     - uses: julia-actions/julia-invalidations@v1
       id: invs_default
-    
+
     - name: Report invalidation counts
       run: |
         echo "Invalidations on default branch: ${{ steps.invs_default.outputs.total }} (${{ steps.invs_default.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
         echo "This branch: ${{ steps.invs_pr.outputs.total }} (${{ steps.invs_pr.outputs.deps }} via deps)" >> $GITHUB_STEP_SUMMARY
     - name: Check if the PR does increase number of invalidations
-      if: steps.invs_pr.outputs.total > steps.invs_default.outputs.total
-      run: exit 1
+      run: |
+        if [ ${{ steps.invs_pr.outputs.total }} -gt ${{ steps.invs_default.outputs.total }} ]; then
+          exit 1
+        fi

--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -613,13 +613,11 @@ end
     return n
 end
 
-const BaseStrs = Union{Char, String, SubString{String}}
+
 Base.string(a::InlineString) = a
 Base.string(a::InlineString...) = _string(a...)
-Base.string(a::BaseStrs, b::InlineString) = _string(a, b)
-Base.string(a::BaseStrs, b::BaseStrs, c::InlineString) = _string(a, b, c)
 
-@inline function _string(a::Union{BaseStrs, InlineString}...)
+@inline function _string(a::InlineString...)
     n = 0
     for v in a
         if v isa Char


### PR DESCRIPTION
This removes the following invalidations:

```
julia> using SnoopCompile;

julia> invalidations = @snoopr using InlineStrings;

inserting string(a::Union{Char, SubString{String}, String}, b::Union{Char, SubString{String}, String}, c::InlineString) @ InlineStrings ~/.julia/packages/InlineStrings/xUsry/src/InlineStrings.jl:620 invalidated:
   backedges: 1: superseding string(xs...) @ Base strings/io.jl:189 with MethodInstance for string(::Char, ::Vararg{Any}) (1 children)
              2: superseding string(xs...) @ Base strings/io.jl:189 with MethodInstance for string(::Any, ::Char, ::Any) (12 children)
              3: superseding string(xs...) @ Base strings/io.jl:189 with MethodInstance for string(::Any, ::String, ::Any) (13 children)
              4: superseding string(xs...) @ Base strings/io.jl:189 with MethodInstance for string(::String, ::String, ::Any) (80 children)
              5: superseding string(xs...) @ Base strings/io.jl:189 with MethodInstance for string(::String, ::String, ::Vararg{Any}) (461 children)
   6 mt_cache
```

Fixes https://github.com/KristofferC/OhMyREPL.jl/issues/361