### PR TITLE
fix `write` to bswap and use the correct size

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -311,10 +311,10 @@ function Base.hash(x::T, h::UInt) where {T <: InlineString}
 end
 
 function Base.write(io::IO, x::T) where {T <: InlineString}
-    ref = Ref{T}(x)
+    ref = Ref{T}(_bswap(x))
     return GC.@preserve ref begin
         ptr = convert(Ptr{UInt8}, Base.unsafe_convert(Ptr{T}, ref))
-        Int(unsafe_write(io, ptr, reinterpret(UInt, sizeof(T))))::Int
+        Int(unsafe_write(io, ptr, reinterpret(UInt, sizeof(x))))::Int
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -570,6 +570,13 @@ end
 @test inlinestrings(["a", "b", ""]) == [String1("a"), String1("b"), String1("")]
 @test String1("") == ""
 
+@testset "write" begin
+    str = InlineString("abc")
+    iob = IOBuffer()
+    write(iob, str)
+    @test String(take!(iob)) == "abc"
+end
+
 # only test package extension on >= 1.9.0
 if VERSION >= v"1.9.0" && Sys.WORD_SIZE == 64
 include(joinpath(dirname(pathof(InlineStrings)), "../ext/tests.jl"))


### PR DESCRIPTION
Before this, this gave:

```julia
str = InlineString("abc")
iob = IOBuffer()
write(iob, str)
String(take!(iob)) == "abc"
# "\x03cba"
```