### PR TITLE
Fix incorrect variable in `repeat`

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -616,7 +616,7 @@ summed_type(a::Type{<:SmallInlineStrings}, b::Type{<:SmallInlineStrings}) = summ
 function Base.repeat(x::T, r::Integer) where {T <: InlineString}
     r < 0 && throw(ArgumentError("can't repeat a string $r times"))
     r == 0 && return ""
-    r == 1 && return s
+    r == 1 && return x
     n = sizeof(x)
     out = Base._string_n(n * r)
     if n == 1 # common case: repeating a single-byte string

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -257,6 +257,9 @@ for S in SUBTYPES
     end
 end
 
+# repeat one-time should return the same object
+@test repeat(InlineString("abc"), 1) === InlineString("abc")
+
 # can't contain NUL when converting to Cstring
 @test_throws ArgumentError Base.cconvert(Cstring, InlineString("a\0c"))
 


### PR DESCRIPTION
Just a small typo fix. 

```julia
julia> i = String15("abc")
"abc"

julia> repeat(i, 2)
"abcabc"

julia> repeat(i, 1)
ERROR: UndefVarError: `s` not defined in `InlineStrings`
Suggestion: check for spelling errors or missing imports.
Stacktrace:
 [1] repeat(x::String15, r::Int64)
   @ InlineStrings ~/Desktop/InlineStrings.jl/src/InlineStrings.jl:619
 [2] top-level scope
   @ REPL[5]:1
```