### PR TITLE
Harden InlineString edge-case behavior

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -186,7 +186,9 @@ for T in (:InlineString1, :InlineString3, :InlineString7, :InlineString15, :Inli
     @eval $T() = Base.zext_int($T, 0x00)
 
     @eval function $T(x::AbstractString)
-        if typeof(x) === String && sizeof($T) <= sizeof(UInt)
+        if codeunit(x) !== UInt8
+            return $T(String(x))
+        elseif typeof(x) === String && sizeof($T) <= sizeof(UInt)
             len = sizeof(x)
             len < sizeof($T) || stringtoolong($T, len)
             y = GC.@preserve x unsafe_load(convert(Ptr{$T}, pointer(x)))
@@ -204,10 +206,12 @@ for T in (:InlineString1, :InlineString3, :InlineString7, :InlineString15, :Inli
     end
 
     @eval function $T(buf::AbstractVector{UInt8}, pos=1, len=length(buf))
-        blen = length(buf)
-        blen < len && buftoosmall(len)
+        len < 0 && invalidlength(len)
         len < sizeof($T) || stringtoolong($T, len)
-        if (blen - pos + 1) < sizeof($T)
+        if len > 0 && (!checkbounds(Bool, buf, pos) || (lastindex(buf) - pos + 1) < len)
+            buftoosmall(len)
+        end
+        if (lastindex(buf) - pos + 1) < sizeof($T)
             # if our buffer isn't long enough to hold a full $T,
             # then we can't do our unsafe_load trick below because we'd be
             # unsafe_load-ing memory from beyond the end of buf
@@ -237,6 +241,7 @@ for T in (:InlineString1, :InlineString3, :InlineString7, :InlineString15, :Inli
                 i += 1
             end
         else
+            len < 0 && invalidlength(len)
             len < sizeof($T) || stringtoolong($T, len)
             for i = 1:len
                 @inbounds y, _ = addcodeunit(y, unsafe_load(ptr, i))
@@ -265,9 +270,11 @@ end
 
 @noinline nullptr(T) = throw(ArgumentError("cannot convert NULL to $T"))
 @noinline buftoosmall(n) = throw(ArgumentError("input buffer too short for requested length: $n"))
+@noinline invalidlength(n) = throw(ArgumentError("length must be nonnegative: $n"))
 @noinline stringtoolong(T, n) = throw(ArgumentError("string too large ($n) to convert to $T"))
 
 function InlineStringType(n::Integer)
+    n < 0 && invalidlength(n)
     n > 255 && stringtoolong(InlineString, n)
     return n < 2   ? InlineString1   : n < 4  ? InlineString3  :
            n < 8   ? InlineString7   : n < 16 ? InlineString15 :
@@ -276,7 +283,10 @@ function InlineStringType(n::Integer)
 end
 
 InlineString(x::InlineString) = x
-InlineString(x::AbstractString)::InlineStringTypes = (InlineStringType(ncodeunits(x)))(x)
+function InlineString(x::AbstractString)::InlineStringTypes
+    codeunit(x) === UInt8 || return InlineString(String(x))
+    return (InlineStringType(ncodeunits(x)))(x)
+end
 
 """
     inline"string"
@@ -301,6 +311,18 @@ Base.:(==)(y::InlineString, x::String) = x == y
 
 Base.cmp(a::T, b::T) where {T <: InlineString} =
     Base.eq_int(a, b) ? 0 : Base.ult_int(a, b) ? -1 : 1
+@inline function _cmp(a::AbstractString, b::AbstractString)
+    al, bl = ncodeunits(a), ncodeunits(b)
+    for i = 1:min(al, bl)
+        ac = @inbounds codeunit(a, i)
+        bc = @inbounds codeunit(b, i)
+        ac == bc || return ifelse(ac < bc, -1, 1)
+    end
+    return cmp(al, bl)
+end
+Base.cmp(a::InlineString, b::InlineString) = _cmp(a, b)
+Base.cmp(a::InlineString, b::Union{String, SubString{String}}) = _cmp(a, b)
+Base.cmp(a::Union{String, SubString{String}}, b::InlineString) = -_cmp(b, a)
 
 @static if isdefined(Base, :hash_bytes)
 
@@ -331,6 +353,10 @@ function Base.write(io::IO, x::T) where {T <: InlineString}
         ptr = convert(Ptr{UInt8}, Base.unsafe_convert(Ptr{T}, ref))
         Int(unsafe_write(io, ptr, reinterpret(UInt, sizeof(T))))::Int
     end
+end
+@static if isdefined(Base, :AnnotatedIOBuffer)
+    Base.write(io::Base.AnnotatedIOBuffer, x::InlineString) =
+        invoke(write, Tuple{Base.AnnotatedIOBuffer, AbstractString}, io, x)
 end
 
 # without this method the fallback will try to write more than the codeunits
@@ -365,6 +391,10 @@ function Base.isascii(x::T) where {T <: InlineString}
         (y & 0x0000ff00) >= 0x00008000 && return false
         (y & 0x000000ff) >= 0x00000080 && return false
         x = Base.lshr_int(x, 32)
+    end
+    for _ = 1:(len & 3)
+        Base.trunc_int(UInt8, x) >= 0x80 && return false
+        x = Base.lshr_int(x, 8)
     end
     return true
 end
@@ -533,18 +563,13 @@ function Base.reverse(s::T) where {T <: InlineString}
         x = Base.or_int(Base.shl_int(_bswap(s), 8 * (sizeof(T) - nc)), len)
         return x
     end
-    x = Base.zext_int(T, Base.trunc_int(UInt8, s))
-    i = 1
-    while i <= nc
-        j = nextind(s, i)
-        _x = Base.lshr_int(s, 8 * (sizeof(T) - (j - 1)))
-        n = j - i
-        _x = Base.and_int(_x, n == 1 ? Base.zext_int(T, 0xff) :
-            n == 2 ? Base.zext_int(T, 0xffff) :
-            n == 3 ? Base.zext_int(T, 0xffffff) :
-                     Base.zext_int(T, 0xffffffff))
-        _x = Base.shl_int(_x, 8 * (sizeof(T) - (nc - (i - 1))))
-        x = Base.or_int(x, _x)
+    x = T()
+    i = nc + 1
+    while i > 1
+        j = prevind(s, i)
+        for k = j:(i - 1)
+            @inbounds x, _ = addcodeunit(x, codeunit(s, k))
+        end
         i = j
     end
     return x
@@ -673,10 +698,8 @@ Base.findnext(r::Regex, s::InlineString, i::Integer) = findnext(r, String(s), i)
 
 # the rest of these methods are copy/pasted from Base strings/string.jl file
 # for efficiency
-Base.@propagate_inbounds function Base.isvalid(x::InlineString, i::Int)
-    @boundscheck checkbounds(Bool, x, i) || throw(BoundsError(x, i))
-    return @inbounds thisind(x, i) == i
-end
+Base.isvalid(x::InlineString, i::Int) =
+    checkbounds(Bool, x, i) && (@inbounds thisind(x, i) == i)
 
 Base.@propagate_inbounds function Base.thisind(s::InlineString, i::Int)
     i == 0 && return 0
@@ -836,7 +859,7 @@ struct InlineStringSortAlg <: Algorithm end
 const InlineStringSort = InlineStringSortAlg()
 
 # Only small-ish InlineStrings benefit from RadixSort algorithm
-Base.Sort.defalg(::AbstractArray{<:Union{SmallInlineStrings, Missing}}) = InlineStringSort
+Base.Sort.defalg(::AbstractArray{<:SmallInlineStrings}) = InlineStringSort
 
 struct Radix
     size::Int
@@ -1014,9 +1037,11 @@ function _inlinestrings(itr, st, ::Type{eT}, IS, res, i) where {eT}
     return res
 end
 
-Base.Broadcast.broadcasted(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
-Base.map(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
-Base.collect(::Type{InlineString}, A::AbstractArray) = inlinestrings(A)
+_inlinestrings_array(A::AbstractArray) = reshape(inlinestrings(A), size(A))
+
+Base.Broadcast.broadcasted(::Type{InlineString}, A::AbstractArray) = _inlinestrings_array(A)
+Base.map(::Type{InlineString}, A::AbstractArray) = _inlinestrings_array(A)
+Base.collect(::Type{InlineString}, A::AbstractArray) = _inlinestrings_array(A)
 
 if !isdefined(Base, :get_extension)
     include("../ext/ParsersExt.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,14 @@ const SUBTYPES = (
     InlineString255,
 )
 
+struct UTF16TestString <: AbstractString
+    data::Vector{UInt16}
+end
+Base.codeunit(::UTF16TestString) = UInt16
+Base.ncodeunits(s::UTF16TestString) = length(s.data)
+Base.codeunit(s::UTF16TestString, i::Integer) = s.data[i]
+Base.String(s::UTF16TestString) = transcode(String, s.data)
+
 @testset "InlineString basics" begin
 
 y = "abcdef"
@@ -55,6 +63,9 @@ x = InlineString7(buf)
 @test x == "hey"
 @test typeof(x) == InlineString7
 @test_throws ArgumentError InlineString7(b"abcdefgh")
+@test_throws ArgumentError InlineString7(buf, 3, 2)
+@test_throws ArgumentError InlineString7(buf, 0, 1)
+@test_throws ArgumentError InlineString7(buf, 1, -1)
 
 buf = Vector{UInt8}("x")
 x = InlineString1(buf, 1, 1)
@@ -67,6 +78,11 @@ x = InlineString1(buf)
 
 # https://github.com/JuliaData/WeakRefStrings.jl/issues/88
 @test InlineString(String1("a")) === String1("a")
+
+utf16 = UTF16TestString(transcode(UInt16, "éβ"))
+@test InlineString(utf16) === String7("éβ")
+@test String7(utf16) === String7("éβ")
+@test_throws ArgumentError String3(utf16)
 
 # https://github.com/JuliaData/InlineStrings.jl/issues/2
 @test eltype(string.(AbstractString[])) == AbstractString
@@ -86,6 +102,9 @@ ptrstr3 = UInt8['h', 'e', 'y', '1', 0x00]
 @test_throws ArgumentError String3(pointer(ptrstr3))
 @test_throws ArgumentError String3(pointer(ptrstr3), 4)
 @test String3(pointer(ptrstr3), 3) === String3("hey")
+@test_throws ArgumentError String3(pointer(ptrstr3), -1)
+
+@test_throws ArgumentError InlineStringType(-1)
 
 # https://github.com/JuliaStrings/InlineStrings.jl/issues/32
 abc = InlineString3("abc")
@@ -357,6 +376,33 @@ const INLINES = map(InlineString, STRINGS)
         ref_cstring = Base.cconvert(Cstring, x)
         @test GC.@preserve ref_cstring unsafe_string(Base.unsafe_convert(Cstring, ref_cstring)) == y
     end
+
+    for y in ("é", "∀", "aé", "éa")
+        x = InlineString(y)
+        @test !isascii(x)
+        @test reverse(x) == reverse(y)
+    end
+    invalid = String(UInt8[0xc0, 0x80])
+    @test codeunits(reverse(InlineString(invalid))) == codeunits(reverse(invalid))
+
+    if isdefined(Base, :AnnotatedIOBuffer)
+        x = InlineString("abc")
+        @test write(Base.AnnotatedIOBuffer(), x) == sizeof(typeof(x))
+    end
+
+    a = String(UInt8[0xf6, 0xc8])
+    b = String(UInt8[0xf6, 0xb4])
+    for x in (a, InlineString(a), InlineString7(a))
+        for y in (b, InlineString(b), InlineString7(b))
+            @test cmp(x, y) == cmp(a, b) == 1
+            @test !isless(x, y)
+        end
+    end
+
+    x = InlineString("é")
+    for i in (-1, 0, ncodeunits(x) + 1, ncodeunits(x) + 2)
+        @test isvalid(x, i) == isvalid(String(x), i) == false
+    end
 end
 
 @testset "`string` / `*`" begin
@@ -497,6 +543,12 @@ end
     x = [missing, String1("b"), String1("a")]
     sort!(x)
     @test isequal(x, ["a", "b", missing])
+
+    for T in (String1, String3, String7)
+        strings = [randstring(rand(0:(sizeof(T) - 1))) for _ = 1:1_000]
+        x = Union{Missing, T}[T.(strings); missing]
+        @test isequal(sort(x), Union{Missing, T}[T.(sort(strings)); missing])
+    end
 end
 
 @testset "inlinestrings" begin
@@ -524,6 +576,13 @@ end
     x = [randstring(i) for i = 1:31]
     @test InlineString.(x) == map(InlineString, x) == collect(InlineString, x)
     @test eltype(InlineString.(x)) == eltype(map(InlineString, x)) == eltype(collect(InlineString, x)) == InlineString31
+
+    x = reshape(Union{Missing, String}["a", missing, "bbb", "cccc"], 2, 2)
+    for y in (InlineString.(x), map(InlineString, x), collect(InlineString, x))
+        @test size(y) == size(x)
+        @test isequal(y, x)
+        @test eltype(y) == Union{Missing, String7}
+    end
 
     # promote all the way to String
     x = inlinestrings(randstring(i) for i = 1:256)


### PR DESCRIPTION
## Summary

- validate buffer slices and explicit lengths before any inbounds or pointer read
- transcode non-`UInt8` strings before selecting or constructing an inline type
- match `String` behavior for short `isascii` inputs, Unicode and malformed-byte reversal, mixed-type ordering, and out-of-range `isvalid`
- preserve array shape during promoted conversion and use Base sorting for arrays that contain `missing`
- resolve the Julia 1.12 `AnnotatedIOBuffer` write intersection
- add regression tests for each corrected path

## Root causes

The buffer constructor compared `len` with the total buffer length. It did not validate the complete slice that starts at `pos`. The optimized path could therefore read outside the requested buffer.

The generic `AbstractString` constructor assumed `UInt8` code units. It passed wide code units to a byte-only builder and selected capacity from the source code-unit count instead of the UTF-8 byte count.

Several string operations had separate boundary faults:

- `isascii` checked only complete four-byte groups and ignored the final one to three bytes.
- `reverse` moved byte groups incorrectly for two-byte and three-byte characters.
- mixed `String` and `InlineString` comparisons used character iteration while same-storage comparisons used byte order. This gave different results for malformed UTF-8.
- `isvalid(s, i)` threw outside the string bounds instead of returning `false` like `String`.

The custom radix sort declared support for `Union{Missing, SmallInlineString}`. The radix loop can only shift primitive inline values. Large arrays therefore failed when the loop reached `missing`.

The array conversion helper returns a vector. The `broadcasted`, `map`, and `collect` entry points returned that vector without restoring the input dimensions.

Julia 1.12 added `write(::AnnotatedIOBuffer, ::AbstractString)`. This intersected with `write(::IO, ::InlineString)`. The patch adds the exact intersection method behind a version feature check.

## Validation

- `julia --startup-file=no --project=. -e 'using Pkg; Pkg.test()'`: 5,232 tests passed
- randomized differential tests against `String`: 1,246,302 checks with no mismatch
- randomized slice-constructor tests: 129,873 passed
- randomized storage, sorting, and serialization tests: 3,233 passed
- compatibility smoke tests passed on Julia 1.6.7, 1.10.11, 1.12.6, and 1.13.0-rc1
- `git diff --check`: passed

The patch adds no exports.

## Scope and known limits

This PR does not claim to fix #90. `pointer(codeunits(::InlineString))` can still return a pointer to a temporary owner. Preserving only the inline value or its `CodeUnits` wrapper does not fix that lifetime problem.

Five broad method ambiguities from #64 also remain. Matrix display alignment from #89 is unchanged.

PR #82 changes the representation-sensitive byte-order paths. If it lands first, the behavioral regression tests from this PR should be retained while the implementation is rebased onto that representation.

Co-authored by Codex
