### PR TITLE
Support Parsers 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,29 @@ jobs:
         with:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  parsers-compat:
+    name: Parsers ${{ matrix.parsers-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        parsers-version:
+          - '2'
+          - '3'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: '1.10'
+      - uses: julia-actions/cache@v2
+      - name: Test selected Parsers major
+        shell: julia --color=yes --startup-file=no {0}
+        env:
+          PARSERS_VERSION: ${{ matrix.parsers-version }}
+        run: |
+          using Pkg
+          Pkg.activate(mktempdir())
+          Pkg.develop(PackageSpec(path=pwd()))
+          Pkg.add(PackageSpec(name="Parsers", version=ENV["PARSERS_VERSION"]))
+          Pkg.test("InlineStrings")

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ ArrowTypes = "31f734f8-188a-4ce0-8406-c8a06bd891cd"
 Parsers = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
 
 [compat]
-Parsers = "2"
+Parsers = "2, 3"
 julia = "1.6"
 
 [extensions]

--- a/ext/ParsersExt.jl
+++ b/ext/ParsersExt.jl
@@ -2,6 +2,8 @@ module ParsersExt
 using Parsers
 using InlineStrings: InlineString, addcodeunit
 
+if isdefined(Parsers, :xparse)
+
 Parsers.xparse(::Type{T}, buf::AbstractString, pos, len, options, ::Type{S}=T) where {T <: InlineString, S} =
     Parsers.xparse(T, codeunits(buf), pos, len, options, S)
 
@@ -54,5 +56,7 @@ function Parsers.xparse(::Type{T}, source::Union{AbstractVector{UInt8}, IO}, pos
     end
     return Parsers.Result{S}(code, res.tlen, x)
 end
+
+end # Parsers 2 xparse API
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,11 @@
 using Test, InlineStrings, Parsers, Serialization, Random
-import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED, INVALID_DELIMITER, INVALID_QUOTED_FIELD, ESCAPED_STRING, NEWLINE, SUCCESS
+
+const _PARSERS_HAS_XPARSE = isdefined(Parsers, :xparse)
+if _PARSERS_HAS_XPARSE
+    import Parsers: SENTINEL, OK, EOF, OVERFLOW, QUOTED, DELIMITED,
+                    INVALID_DELIMITER, INVALID_QUOTED_FIELD, ESCAPED_STRING,
+                    NEWLINE, SUCCESS
+end
 
 const SUBTYPES = (
     InlineString1,
@@ -381,7 +387,8 @@ end
     @test String3(a) * String3(b) * String7(b) isa InlineString15
 end
 
-@testset "InlineString parsing" begin
+if _PARSERS_HAS_XPARSE
+@testset "InlineString parsing with Parsers 2" begin
 testcases = [
     ("", InlineString7(""), NamedTuple(), OK | EOF),
     (" ", InlineString7(" "), NamedTuple(), OK | EOF),
@@ -460,6 +467,7 @@ res = Parsers.xparse(InlineString7, buf, pos, len, opts, Any)
 @test res.val == "abc"
 
 end # @testset
+end # Parsers 2 xparse API
 
 @testset "InlineString Serialization symmetry" begin
     for str in ("",  "🍕", "a", "a"^3, "a"^7, "a"^15, "a"^31, "a"^63, "a"^127, "a"^255)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,6 +7,14 @@ if _PARSERS_HAS_XPARSE
                     NEWLINE, SUCCESS
 end
 
+@testset "Parsers extension loading" begin
+    if isdefined(Base, :get_extension)
+        @test Base.get_extension(InlineStrings, :ParsersExt) isa Module
+    else
+        @test isdefined(InlineStrings, :ParsersExt)
+    end
+end
+
 const SUBTYPES = (
     InlineString1,
     InlineString3,


### PR DESCRIPTION
## Summary

- Allow Parsers 2 and Parsers 3.
- Keep the existing `xparse` extension only when Parsers provides that API.
- Run `xparse`-specific tests only with Parsers 2.
- Test both supported Parsers majors explicitly in CI.

## Why

Parsers 3 removed the old `xparse` custom-string API. InlineStrings does not need a replacement parser method. The package that reads the input owns string storage and conversion.

The existing Parsers 2 behavior stays unchanged. With Parsers 3, the extension loads as a no-op.

## Validation

- Julia 1.10.11 with Parsers 2.8.7: 5,181 / 5,181 checks passed.
- Julia 1.10.11 with Parsers 3.0.0: 5,102 / 5,102 checks passed.
- Julia 1.6.7 with Parsers 2.8.7 passed.
- Julia 1.9.4 default resolution selected Parsers 2.8.7 and passed.
- Julia 1.12.7 with Parsers 3.0.0 passed.
- Arrow.jl interop passed in both Parsers-major lanes.

Co-authored by Codex