### PR TITLE
Fix InlineCodeUnits byte size

### DIFF
--- a/src/InlineStrings.jl
+++ b/src/InlineStrings.jl
@@ -194,6 +194,7 @@ struct InlineCodeUnits{T <: InlineString} <: AbstractVector{UInt8}
 end
 Base.codeunits(s::InlineString) = InlineCodeUnits(s)
 Base.size(c::InlineCodeUnits) = (ncodeunits(c.s),)
+Base.sizeof(c::InlineCodeUnits) = ncodeunits(c.s)
 Base.IndexStyle(::Type{<:InlineCodeUnits}) = IndexLinear()
 Base.@propagate_inbounds Base.getindex(c::InlineCodeUnits, i::Int) = codeunit(c.s, i)
 Base.write(io::IO, c::InlineCodeUnits) = write(io, c.s)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -192,6 +192,7 @@ S = InlineString15
 # check that writing code units works as expected
 io = IOBuffer()
 cu = codeunits(InlineString("hello"))
+@test sizeof(cu) == 5
 @test write(io, cu) == 5
 @test take!(io) == codeunits("hello")
 


### PR DESCRIPTION
`sizeof(codeunits(x))` currently reports the fixed storage size in 2.0 instead of the logical byte count. CSV.write uses this value and writes padding plus the capacity byte.

This defines the expected byte size for `InlineCodeUnits` and adds a regression test.

Validated with the full InlineStrings suite, a focused CSV.write round trip, and the OMOPVocabMapper suite.

Co-authored by Codex
